### PR TITLE
enabled tracking of all open orders instead of requiring symbol parameter

### DIFF
--- a/node-binance-api.js
+++ b/node-binance-api.js
@@ -406,7 +406,9 @@ module.exports = function() {
 			});
 		},
 		openOrders: function(symbol, callback) {
-			signedRequest(base+"v3/openOrders", {symbol:symbol}, function(data) {
+			let data = symbol ? {symbol:symbol} : {};
+			
+			signedRequest(base+"v3/openOrders", data, function(data) {
 				return callback.call(this, data, symbol);
 			});
 		},


### PR DESCRIPTION
This was a simple modification to the `openOrders` request to allow entering a blank string or null for the `symbol` parameter to retrieve all of the account's open orders.