### PR TITLE
Added optional params to get candlestick data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1220,14 +1220,17 @@ binance.prevDay("BNBBTC", function(prevDay, symbol) {
 ```
 
 #### Get Kline/candlestick data for a symbol
+You can use the optional API parameters for getting historical candlesticks, these are useful if you want to import data from earlier back in time.
+Optional parameters: limit (max/default 500), startTime, endTime.
+
 ```javascript
-// Periods: 1m,3m,5m,15m,30m,1h,2h,4h,6h,8h,12h,1d,3d,1w,1M
+// Intervals: 1m,3m,5m,15m,30m,1h,2h,4h,6h,8h,12h,1d,3d,1w,1M
 binance.candlesticks("BNBBTC", "5m", function(ticks, symbol) {
 	console.log("candlesticks()", ticks);
 	let last_tick = ticks[ticks.length - 1];
 	let [time, open, high, low, close, volume, closeTime, assetVolume, trades, buyBaseVolume, buyAssetVolume, ignored] = last_tick;
 	console.log(symbol+" last close: "+close);
-});
+}, {limit: 500, endTime: 1514764800000});
 ```
 
 # WebSockets Implementation

--- a/node-binance-api.js
+++ b/node-binance-api.js
@@ -605,8 +605,9 @@ Move this to a future release v0.4.0
 			}
 			return {open:open, high:high, low:low, close:close, volume:volume};
 		},
-		candlesticks: function(symbol, interval = '5m', callback) { //1m,3m,5m,15m,30m,1h,2h,4h,6h,8h,12h,1d,3d,1w,1M
-			publicRequest(base+'v1/klines', {symbol:symbol, interval:interval}, function(data) {
+		candlesticks: function(symbol, interval, callback, options = {limit:500}) { // additional options: startTime, endTime
+		  let params = Object.assign({symbol:symbol, interval:interval}, options);
+			publicRequest(base+'v1/klines', params, function(data) {
 				return callback.call(this, data, symbol);
 			});
 		},


### PR DESCRIPTION
This is useful if someone wants to import data from earlier back in time.
Also removed the default 5m interval (regular parameters (callback) should not come after default ones).

This might break functionality for people who relied on the default interval.