### PR TITLE
adding empty {} to error processed API requested

### DIFF
--- a/node-binance-api.js
+++ b/node-binance-api.js
@@ -42,10 +42,10 @@ module.exports = function() {
 			if ( !callback ) return;
 
 			if ( error )
-				return callback( error );
+				return callback( error, {});
 
 			if ( response && response.statusCode !== 200 )
-				return callback( response );
+				return callback( response, {} );
 
 			return callback( null, JSON.parse(body) );
 		});
@@ -68,10 +68,10 @@ module.exports = function() {
 			if ( !callback ) return;
 
 			if ( error )
-				return callback( error );
+				return callback( error, {} );
 
 			if ( response && response.statusCode !== 200 )
-				return callback( response );
+				return callback( response, {} );
 
 			return callback( null, JSON.parse(body) );
 		});
@@ -100,10 +100,10 @@ module.exports = function() {
 			if ( !callback ) return;
 
 			if ( error )
-				return callback( error );
+				return callback( error, {} );
 
 			if ( response && response.statusCode !== 200 )
-				return callback( response );
+				return callback( response, {} );
 
 			return callback( null, JSON.parse(body) );
 		});


### PR DESCRIPTION
Should help prevent uncaught exceptions as a result of a undefined "data" prop being processed regardless of if an error is returned or not.

I encountered this with the described:  https://github.com/jaggedsoft/node-binance-api/issues/66