### PR TITLE
Fixes issue with argument list in advanced parameters

### DIFF
--- a/examples/advanced.md
+++ b/examples/advanced.md
@@ -4,7 +4,7 @@
 ```js
 //minQty = minimum order quantity
 //minNotional = minimum order value (price * quantity)
-binance.exchangeInfo(function(data) {
+binance.exchangeInfo(function(error, data) {
 	let minimums = {};
 	for ( let obj of data.symbols ) {
 		let filters = {minNotional:0.001,minQty:1,maxQty:10000000,stepSize:1,minPrice:0.00000001,maxPrice:100000};


### PR DESCRIPTION
Hi team,

I've copied paste this example and I've noticed that data was `undefined` and it was easy to tell that the standard `error` first argument was missing. I thought I would send a quick PR that fixes it for folks trying to use this example.

I didn't bother to add:

```
if (!error) {
  ...
}
```

:octocat::heart: