### PR TITLE
Redirect logs from node-binance-api

### DIFF
--- a/README.md
+++ b/README.md
@@ -1428,6 +1428,12 @@ Having problems? Try adding `useServerTime` to your options:
 binance.options({
 	'APIKEY': 'xxx',
 	'APISECRET': 'xxx',
-	'useServerTime': true
+  'useServerTime': true,
+  'onLogs': log => {
+    console.log(log);
+  },
+  onError: err => {
+    console.error(err);
+  }
 });
 ```

--- a/README.md
+++ b/README.md
@@ -17,10 +17,16 @@ npm install node-binance-api --save
 ```javascript
 const binance = require('node-binance-api');
 binance.options({
-	APIKEY: '<key>',
-	APISECRET: '<secret>',
-	useServerTime: true, // If you get timestamp errors, synchronize to server time at startup
-	test: true // If you want to use sandbox mode where orders are simulated
+  APIKEY: '<key>',
+  APISECRET: '<secret>',
+  useServerTime: true, // If you get timestamp errors, synchronize to server time at startup
+  test: true, // If you want to use sandbox mode where orders are simulated
+  'onLogs': log => {
+    console.log(log);
+  },
+  onError: err => {
+    console.error(err);
+  }
 });
 ```
 
@@ -1426,8 +1432,8 @@ Verify that your system time is correct. If you have any suggestions don't hesti
 Having problems? Try adding `useServerTime` to your options:
 ```js
 binance.options({
-	'APIKEY': 'xxx',
-	'APISECRET': 'xxx',
+  'APIKEY': 'xxx',
+  'APISECRET': 'xxx',
   'useServerTime': true,
   'onLogs': log => {
     console.log(log);


### PR DESCRIPTION
As discussed in #90, it would be great if we could catch the logs and error made from node-binance-api
In the binance.options there are now 2 more variable onLogs and onError, both are function, by default set to a simple console.log/console.error so it would not change anything.
But if a user want to save them, or ignore them completly, he could override the functions.