### PR TITLE
[#114] Fix `websockets.prevDay()` reconnect

### DIFF
--- a/node-binance-api.js
+++ b/node-binance-api.js
@@ -1003,7 +1003,7 @@ LIMIT_MAKER
             },
             prevDay: function prevDay(symbols, callback) {
                 let reconnect = function() {
-                    if ( options.reconnect ) prevDay(symbol, callback);
+                    if ( options.reconnect ) prevDay(symbols, callback);
                 };
 
                 // Combine stream for array of symbols


### PR DESCRIPTION
Fixes: #114 

`reconnect()` defined in `websockets.prevDay()` was using incorrect argument name. 🤦‍♂️ 