### PR TITLE
check if messageQueue[symbol] is an array

### DIFF
--- a/node-binance-api.js
+++ b/node-binance-api.js
@@ -854,7 +854,7 @@ LIMIT_MAKER
 
                 let handleDepthStreamData = function(depth) {
                     let symbol = depth.s;
-                    if ( !info[symbol].firstUpdateId ) {
+                    if (messageQueue[symbol] && !info[symbol].firstUpdateId ) {
                         messageQueue[symbol].push(depth);
                     } else {
                         depthHandler(depth);


### PR DESCRIPTION
Got some errors when fetching the market depth for all symbols. Turns out that the messageQueue is not initiated with an empty array for each symbol. 

It makes sense to first check it the messageQueue for the symbol is set. If not, then it falls back to the depthhandler function.

I tested it locally, error is gone, all bids and asks are getting calculated correctly. Hope this helps to make this wonderful package more stable guys. Cheers.