### PR TITLE
Fix error "Cannot read property 'push' of undefined"

### DIFF
--- a/node-binance-api.js
+++ b/node-binance-api.js
@@ -879,7 +879,7 @@ LIMIT_MAKER
                 let handleDepthStreamData = function(depth) {
                     let symbol = depth.s;
                     let context = _depthCacheContext[symbol];
-                    if ( !context.snapshotUpdateId ) {
+                    if (context.messageQueue && !context.snapshotUpdateId ) {
                         context.messageQueue.push(depth);
                     } else {
                         depthHandler(depth);


### PR DESCRIPTION
Hi,

Fixed these errors when checking the marketDepth stream:

'CombinedStream: Parse error: Cannot read property \'push\' of undefined' 

I added a check to see if `context.messageQueue` is there. If not, it falls back to the depthHandler function. 

Only tested this locally, but errors went away and worked like a charm again!