### PR TITLE
allow invocation of binance.websockets.subsubscribeCombined()

### DIFF
--- a/node-binance-api.js
+++ b/node-binance-api.js
@@ -852,6 +852,9 @@ LIMIT_MAKER
             subscribe: function(url, callback, reconnect = false) {
                 return subscribe(url, callback, reconnect);
             },
+            subscribeCombined: function(url, callback, reconnect = false) {
+                return subscribeCombined(url, callback, reconnect);
+            },
             subscriptions: function() {
                 return subscriptions;
             },


### PR DESCRIPTION
I think this function will be very useful to developers who want to listen to different types of streams via one websocket (e.g. ticker + order book).