### PR TITLE
Added rawTrades to the ws api as a copy-paste-and-change of trades.

### DIFF
--- a/node-binance-api.js
+++ b/node-binance-api.js
@@ -1675,7 +1675,7 @@ module.exports = function() {
             },
 
             /**
-            * Websocket trades
+            * Websocket aggregated trades
             * @param {array/string} symbols - an array or string of symbols to query
             * @param {function} callback - callback function
             * @return {string} the websocket endpoint
@@ -1698,9 +1698,34 @@ module.exports = function() {
                 }
                 return subscription.endpoint;
             },
+            
+            /**
+            * Websocket raw trades
+            * @param {array/string} symbols - an array or string of symbols to query
+            * @param {function} callback - callback function
+            * @return {string} the websocket endpoint
+            */
+            rawTrades: function rawTrades(symbols, callback) {
+                let reconnect = function() {
+                    if ( options.reconnect ) trades(symbols, callback);
+                };
+
+                let subscription;
+                if ( Array.isArray(symbols) ) {
+                    if ( !isArrayUnique(symbols) ) throw Error('trades: "symbols" cannot contain duplicate elements.');
+                    let streams = symbols.map(function(symbol) {
+                        return symbol.toLowerCase()+'@trade';
+                    });
+                    subscription = subscribeCombined(streams, callback, reconnect);
+                } else {
+                    let symbol = symbols;
+                    subscription = subscribe(symbol.toLowerCase()+'@trade', callback, reconnect);
+                }
+                return subscription.endpoint;
+            },
 
             /**
-            * Websocket trades
+            * Websocket klines
             * @param {array/string} symbols - an array or string of symbols to query
             * @param {string} interval - the time interval
             * @param {function} callback - callback function

--- a/node-binance-api.js
+++ b/node-binance-api.js
@@ -1698,7 +1698,7 @@ module.exports = function() {
                 }
                 return subscription.endpoint;
             },
-            
+
             /**
             * Websocket raw trades
             * @param {array/string} symbols - an array or string of symbols to query
@@ -1707,7 +1707,7 @@ module.exports = function() {
             */
             rawTrades: function rawTrades(symbols, callback) {
                 let reconnect = function() {
-                    if ( options.reconnect ) trades(symbols, callback);
+                    if ( options.reconnect ) rawTrades(symbols, callback);
                 };
 
                 let subscription;
@@ -1723,7 +1723,7 @@ module.exports = function() {
                 }
                 return subscription.endpoint;
             },
-
+            
             /**
             * Websocket klines
             * @param {array/string} symbols - an array or string of symbols to query

--- a/node-binance-api.js
+++ b/node-binance-api.js
@@ -1723,7 +1723,7 @@ module.exports = function() {
                 }
                 return subscription.endpoint;
             },
-            
+
             /**
             * Websocket klines
             * @param {array/string} symbols - an array or string of symbols to query

--- a/test.js
+++ b/test.js
@@ -974,6 +974,28 @@ describe( 'Websockets trades', function() {
   });
 });
 
+
+describe( 'Websockets raw trades', function() {
+  let trades;
+  let cnt = 0;
+  /*global beforeEach*/
+  beforeEach(function (done) {
+    this.timeout( TIMEOUT );
+    binance.websockets.rawTrades(['BNBBTC', 'ETHBTC'], e_trades => {
+      cnt++;
+      if ( cnt > 1 ) return;
+      trades = e_trades;
+      stopSockets();
+      done();
+    });
+  });
+
+  it( 'Calls trades websocket', function() {
+    assert( typeof ( trades ) === 'object', WARN_SHOULD_BE_OBJ );
+    assert( trades !== null, WARN_SHOULD_BE_NOT_NULL );
+  });
+});
+
 describe( 'depthCache', function() {
   it( 'depthCache', function( done ) {
     binance.depthCache( 'BNBBTC' );


### PR DESCRIPTION
Binance offers the ability to stream the raw trades via the websocket. It's exactly the same as regular agg trades, but instead of using @aggTrade you just use @trade. 

This PR is a simple copy paste of the websocket trades function with the modified @ param 