### PR TITLE
make naming more consistent

### DIFF
--- a/node-binance-api.js
+++ b/node-binance-api.js
@@ -1679,7 +1679,7 @@ module.exports = function() {
             * @param {function} callback - callback function
             * @return {string} the websocket endpoint
             */
-            trades: function trades(symbols, callback) {
+            aggTrades: function trades(symbols, callback) {
                 let reconnect = function() {
                     if ( options.reconnect ) trades(symbols, callback);
                 };
@@ -1704,9 +1704,9 @@ module.exports = function() {
             * @param {function} callback - callback function
             * @return {string} the websocket endpoint
             */
-            rawTrades: function rawTrades(symbols, callback) {
+            trades: function trades(symbols, callback) {
                 let reconnect = function() {
-                    if ( options.reconnect ) rawTrades(symbols, callback);
+                    if ( options.reconnect ) trades(symbols, callback);
                 };
 
                 let subscription;

--- a/test.js
+++ b/test.js
@@ -953,13 +953,13 @@ describe( 'Websockets depth', function() {
   });
 });
 
-describe( 'Websockets trades', function() {
+describe( 'Websockets aggregated trades', function() {
   let trades;
   let cnt = 0;
   /*global beforeEach*/
   beforeEach(function (done) {
     this.timeout( TIMEOUT );
-    binance.websockets.trades(['BNBBTC', 'ETHBTC'], e_trades => {
+    binance.websockets.aggTrades(['BNBBTC', 'ETHBTC'], e_trades => {
       cnt++;
       if ( cnt > 1 ) return;
       trades = e_trades;
@@ -975,13 +975,13 @@ describe( 'Websockets trades', function() {
 });
 
 
-describe( 'Websockets raw trades', function() {
+describe( 'Websockets (raw) trades', function() {
   let trades;
   let cnt = 0;
   /*global beforeEach*/
   beforeEach(function (done) {
     this.timeout( TIMEOUT );
-    binance.websockets.rawTrades(['BNBBTC', 'ETHBTC'], e_trades => {
+    binance.websockets.trades(['BNBBTC', 'ETHBTC'], e_trades => {
       cnt++;
       if ( cnt > 1 ) return;
       trades = e_trades;


### PR DESCRIPTION
I found it confusing to access `aggTrades` under `trades`, 
since there is another stream called `trades`.