### PR TITLE
Fixes Issue #211

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -585,11 +585,6 @@
         }
       }
     },
-    "crypto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz",
-      "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig=="
-    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "Binance API for node https://github.com/jaggedsoft/node-binance-api",
   "main": "node-binance-api.js",
   "dependencies": {
-    "crypto": "^1.0.1",
     "dns-sync": "^0.1.3",
     "fs": "0.0.1-security",
     "https-proxy-agent": "^2.2.1",


### PR DESCRIPTION
Removing the crypto dependency in both the package.json and package-lock.json files removed the audit error for me. Tested using ``npm pack`` and then installing the resulting tarball locally.