### PR TITLE
Set mapLimit to 50 at a time to prevent rate limit when fetching inia…

### DIFF
--- a/node-binance-api.js
+++ b/node-binance-api.js
@@ -1735,7 +1735,7 @@ let api = function Binance() {
                         return symbol.toLowerCase() + '@depth';
                     });
                     subscription = subscribeCombined(streams, handleDepthStreamData, reconnect, function () {
-                        async.mapLimit(symbols, symbols.length, getSymbolDepthSnapshot, (err, results) => {
+                        async.mapLimit(symbols, 50, getSymbolDepthSnapshot, (err, results) => {
                             if (err) throw err;
                             results.forEach(updateSymbolDepthCache);
                         });

--- a/test.js
+++ b/test.js
@@ -25,7 +25,7 @@ let binance = new Binance();
 let util = require('util');
 
 let num_pairs = 299;
-let num_currencies = 156;
+let num_currencies = 155;
 
 let logger = {
   log: function (msg) {


### PR DESCRIPTION
- mapLimit with the whole symbols length will cause rate limiting errors from time to time.  Reducing it to ~50 at a time helped prevent this.  

- Also saw broken unit test due to Binance ridding of a symbol so fixed that too