### PR TITLE
Better promisifiable historicalTrades

### DIFF
--- a/node-binance-api.js
+++ b/node-binance-api.js
@@ -1479,9 +1479,9 @@ let api = function Binance() {
         * @param {int} fromId - from this id
         * @return {undefined}
         */
-        historicalTrades: function (symbol, callback, limit = 500, fromId = false) {
-            let parameters = { symbol: symbol, limit: limit };
-            if (fromId) parameters.fromId = fromId;
+        historicalTrades: function (options = {limit: 500, fromId: false}, callback) {
+            let parameters = { symbol: options.symbol, limit: options.limit };
+            if (fromId) parameters.fromId = options.fromId;
             marketRequest(base + 'v1/historicalTrades', parameters, callback);
         },
 


### PR DESCRIPTION
Using object on the first parameter of historicalTrades would allow other parameters to be used after being promisified.