### PR TITLE
Improve Depth Cache Performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1646,7 +1646,7 @@ binance.useServerTime(function() {
 });
 ```
 
-Thank you to all contributors: dmzoneill, dmitriz, keith1024, pavlovdog, usama33, yanislk, learnathoner, vaielab, nickreese, Tuitio, grandmore, itnok, CollinEstes, sethyx, mstijak, MadDeveloper, balthazar, bitoiu, matthewwoop, robaleman, hems and others!
+Thank you to all contributors: bmino, dmzoneill, dmitriz, keith1024, pavlovdog, usama33, yanislk, learnathoner, vaielab, nickreese, Tuitio, grandmore, itnok, CollinEstes, sethyx, mstijak, MadDeveloper, balthazar, bitoiu, matthewwoop, robaleman, hems and others!
 
 > # ⚠️ Binance no longer offers support for API projects.
 > ## No support is offered. No questions will be answered. Pull requests are still welcome.

--- a/node-binance-api.js
+++ b/node-binance-api.js
@@ -716,21 +716,23 @@ let api = function Binance() {
         let updateDepthCache = function () {
             Binance.depthCache[symbol].eventTime = depth.E;
             for (obj of depth.b) { //bids
-                Binance.depthCache[symbol].bids[obj[0]] = parseFloat(obj[1]);
                 if (obj[1] === '0.00000000') {
                     delete Binance.depthCache[symbol].bids[obj[0]];
+                } else {
+                    Binance.depthCache[symbol].bids[obj[0]] = parseFloat(obj[1]);
                 }
             }
             for (obj of depth.a) { //asks
-                Binance.depthCache[symbol].asks[obj[0]] = parseFloat(obj[1]);
                 if (obj[1] === '0.00000000') {
                     delete Binance.depthCache[symbol].asks[obj[0]];
+                } else {
+                    Binance.depthCache[symbol].asks[obj[0]] = parseFloat(obj[1]);
                 }
             }
             context.skipCount = 0;
             context.lastEventUpdateId = depth.u;
             context.lastEventUpdateTime = depth.E;
-        }
+        };
 
         // This now conforms 100% to the Binance docs constraints on managing a local order book
         if (context.lastEventUpdateId) {


### PR DESCRIPTION
This alters the logic when receiving a depthCache event with a quantity of 0. When watching many depth cache websockets, this makes a difference.

Before:
Add the new entry to the depth cache
Delete the depth cache entry

Now:
Simply delete the depth cache entry if it exists