### PR TITLE
345 clear depth cache

### DIFF
--- a/node-binance-api.js
+++ b/node-binance-api.js
@@ -1842,6 +1842,20 @@ let api = function Binance() {
             },
 
             /**
+             * Clear websocket depthcache
+             * @param {String|Array} symbols   - a single symbol, or an array of symbols, to clear the cache of
+             */
+            clearDepthCache(symbols) {
+                const symbolsArr = [];
+                if (!Array.isArray(symbols)) {
+                    symbolsArr = [symbols]
+                }
+                symbolsArr.forEach((thisSymbol) => {
+                    delete Binance.depthCache[thisSymbol];
+                });
+            },
+
+            /**
              * Websocket staggered depth cache
              * @param {array/string} symbols - an array of symbols to query
              * @param {function} callback - callback function

--- a/node-binance-api.js
+++ b/node-binance-api.js
@@ -1846,10 +1846,7 @@ let api = function Binance() {
              * @param {String|Array} symbols   - a single symbol, or an array of symbols, to clear the cache of
              */
             clearDepthCache(symbols) {
-                const symbolsArr = [];
-                if (!Array.isArray(symbols)) {
-                    symbolsArr = [symbols]
-                }
+                const symbolsArr = Array.isArray(symbols) ? symbols : [symbols];
                 symbolsArr.forEach((thisSymbol) => {
                     delete Binance.depthCache[thisSymbol];
                 });


### PR DESCRIPTION
Allow deletion of depth cache data. This can be helpful after a user terminates the connection and is done with the data.

used via `binance.websockets.clearDepthCache('btcusdc')`