### PR TITLE
Conditionally promisified API calls for alternative syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -1584,7 +1584,6 @@ binance.withdraw("BTC", "1C5gqLRs96Xq4V2ZZAR1347yUCpHie7sa", 0.2);
 [newOrderRespType example](https://github.com/jaggedsoft/node-binance-api/blob/master/examples/advanced.md#neworderresptype-example-when-placing-orders)\
 [Recent Trades (historicalTrades, recentTrades, aggTrades functions)](https://github.com/jaggedsoft/node-binance-api/blob/master/examples/advanced.md#recent-trades-historicaltrades-recenttrades-aggtrades-functions)\
 [Terminate WebSocket connections](https://github.com/jaggedsoft/node-binance-api/blob/master/examples/advanced.md#terminate-websocket-connections)\
-[User Data: Account Balance Updates, Trade Updates, New Orders, Filled Orders, Cancelled Orders via WebSocket](https://github.com/jaggedsoft/node-binance-api/blob/master/examples/advanced.md#user-data-account-balance-updates-trade-updates-new-orders-filled-orders-cancelled-orders-via-websocket)
 [User Data: Account Balance Updates, Trade Updates, New Orders, Filled Orders, Cancelled Orders via WebSocket](https://github.com/jaggedsoft/node-binance-api/blob/master/examples/advanced.md#user-data-account-balance-updates-trade-updates-new-orders-filled-orders-cancelled-orders-via-websocket)\
 [Asynchronous Syntax Options](https://github.com/jaggedsoft/node-binance-api/blob/master/examples/advanced.md#asynchronous-syntax-options)
 

--- a/README.md
+++ b/README.md
@@ -1585,6 +1585,8 @@ binance.withdraw("BTC", "1C5gqLRs96Xq4V2ZZAR1347yUCpHie7sa", 0.2);
 [Recent Trades (historicalTrades, recentTrades, aggTrades functions)](https://github.com/jaggedsoft/node-binance-api/blob/master/examples/advanced.md#recent-trades-historicaltrades-recenttrades-aggtrades-functions)\
 [Terminate WebSocket connections](https://github.com/jaggedsoft/node-binance-api/blob/master/examples/advanced.md#terminate-websocket-connections)\
 [User Data: Account Balance Updates, Trade Updates, New Orders, Filled Orders, Cancelled Orders via WebSocket](https://github.com/jaggedsoft/node-binance-api/blob/master/examples/advanced.md#user-data-account-balance-updates-trade-updates-new-orders-filled-orders-cancelled-orders-via-websocket)
+[User Data: Account Balance Updates, Trade Updates, New Orders, Filled Orders, Cancelled Orders via WebSocket](https://github.com/jaggedsoft/node-binance-api/blob/master/examples/advanced.md#user-data-account-balance-updates-trade-updates-new-orders-filled-orders-cancelled-orders-via-websocket)\
+[Asynchronous Syntax Options](https://github.com/jaggedsoft/node-binance-api/blob/master/examples/advanced.md#asynchronous-syntax-options)
 
 
 ### Proxy Support
@@ -1660,4 +1662,3 @@ Thank you to all contributors: bmino, dmzoneill, dmitriz, keith1024, pavlovdog, 
 [![Views](http://hits.dwyl.io/jaggedsoft/node-binance-api.svg)](http://hits.dwyl.io/jaggedsoft/node-binance-api)
 [![jaggedsoft on Twitter](https://img.shields.io/twitter/follow/jaggedsoft.svg?style=social)](https://twitter.com/jaggedsoft)
 [![Chartaholic on Twitter](https://img.shields.io/twitter/follow/Chartaholic.svg?style=social)](https://twitter.com/Chartaholic)
-

--- a/examples/advanced.md
+++ b/examples/advanced.md
@@ -1,4 +1,4 @@
-![Downloads](https://img.shields.io/npm/dt/node-binance-api.svg?style=for-the-badge&maxAge=86400) ![Stars](https://img.shields.io/github/stars/jaggedsoft/node-binance-api.svg?style=for-the-badge&label=Stars) ![Contributors](https://img.shields.io/github/contributors/jaggedsoft/node-binance-api.svg?style=for-the-badge&maxAge=86400) ![Issues](https://img.shields.io/github/issues/jaggedsoft/node-binance-api.svg?style=for-the-badge&maxAge=86400) ![Issue Closure](https://img.shields.io/issuestats/i/github/jaggedsoft/node-binance-api.svg?style=for-the-badge&maxAge=86400) 
+![Downloads](https://img.shields.io/npm/dt/node-binance-api.svg?style=for-the-badge&maxAge=86400) ![Stars](https://img.shields.io/github/stars/jaggedsoft/node-binance-api.svg?style=for-the-badge&label=Stars) ![Contributors](https://img.shields.io/github/contributors/jaggedsoft/node-binance-api.svg?style=for-the-badge&maxAge=86400) ![Issues](https://img.shields.io/github/issues/jaggedsoft/node-binance-api.svg?style=for-the-badge&maxAge=86400) ![Issue Closure](https://img.shields.io/issuestats/i/github/jaggedsoft/node-binance-api.svg?style=for-the-badge&maxAge=86400)
 ## Advanced Examples
 
 #### exchangeInfo(): Pull minimum order size, quantity, etc.
@@ -178,7 +178,7 @@ binance.marketBuy("BNBBTC", quantity, flags, function(error, response) {
 ```
 ![image](https://user-images.githubusercontent.com/4283360/36094574-acb15ae6-0fa3-11e8-9209-e6f528e09e84.png)
 > First price: 0.00106140
-  
+
 #### Recent Trades (historicalTrades, recentTrades, aggTrades functions)
 
 ```js
@@ -197,4 +197,30 @@ binance.recentTrades("BNBBTC", (error, response)=>{
 binance.historicalTrades("BNBBTC", (error, response)=>{
 	console.log("historicalTrades", response);
 });
+```
+
+#### Asynchronous Syntax Options
+> The examples below show three most common syntaxes for asynchronous API calls and their respective methods of error handling. If you do not pass a callback function as an argument, the API call returns a promise instead.
+
+```js
+const callback = binance.prices("NEOBTC", (error, response) => {
+  if (error) {
+    console.error(error)
+  } else {
+    console.log(response)
+  }
+})
+
+const classicPromise = binance.prices("NEOBTC")
+  .then(response => console.log(response))
+  .catch(error => console.error(error))
+
+const asyncAwait = (async _ => {
+  try {
+    const response = await binance.prices("NEOBTC")
+    console.log(response)
+  } catch (error) {
+    console.error(error)
+  }
+})()
 ```

--- a/node-binance-api.js
+++ b/node-binance-api.js
@@ -1499,7 +1499,7 @@ let api = function Binance() {
                     return resolve(result);
                   });
                 });
-            };
+            }
             request(addProxy(opt), function (error, response, body) {
                 if (error) return callback(error);
                 if (response.statusCode !== 200) return callback(response);

--- a/node-binance-api.js
+++ b/node-binance-api.js
@@ -573,7 +573,7 @@ let api = function Binance() {
             return convertData(data);
         }
     }
-    
+
     /**
      * Parses the previous day stream and calls the user callback with friendly object
      * @param {object} data - user data callback data type
@@ -1263,15 +1263,23 @@ let api = function Binance() {
                 url: base + 'v3/avgPrice?symbol=' + symbol,
                 timeout: Binance.options.recvWindow
             };
-
+            if (!callback) {
+                return new Promise((resolve, reject) => {
+                  request(addProxy(opt), function (error, response, body) {
+                    if (error) return reject(error);
+                    if (response.statusCode !== 200) return reject(response);
+                    let result = {};
+                    result[symbol] = JSON.parse(response.body).price;
+                    return resolve(result);
+                  });
+                });
+            };
             request(addProxy(opt), function (error, response, body) {
-                if (!callback) return;
-
                 if (error) return callback(error);
-
-                if (response && response.statusCode !== 200) return callback(response);
-
-                if (callback) return callback(null, priceData(JSON.parse(body)));
+                if (response.statusCode !== 200) return callback(response);
+                let result = {};
+                result[symbol] = JSON.parse(response.body).price;
+                return callback(null, result);
             });
         },
 
@@ -1289,15 +1297,19 @@ let api = function Binance() {
                 url: base + 'v3/ticker/price' + params,
                 timeout: Binance.options.recvWindow
             };
-
+            if (!callback) {
+                return new Promise((resolve, reject) => {
+                  request(addProxy(opt), function (error, response, body) {
+                    if (error) return reject(error);
+                    if (response.statusCode !== 200) return reject(response);
+                    return resolve(priceData(JSON.parse(body)));
+                  });
+                });
+            };
             request(addProxy(opt), function (error, response, body) {
-                if (!callback) return;
-
                 if (error) return callback(error);
-
-                if (response && response.statusCode !== 200) return callback(response);
-
-                if (callback) return callback(null, priceData(JSON.parse(body)));
+                if (response.statusCode !== 200) return callback(response);
+                return callback(null, priceData(JSON.parse(body)));
             });
         },
 
@@ -1315,18 +1327,21 @@ let api = function Binance() {
                 url: base + 'v3/ticker/bookTicker' + params,
                 timeout: Binance.options.recvWindow
             };
-
-            request(addProxy(opt), function (error, response, body) {
-                if (!callback) return;
-
-                if (error) return callback(error);
-
-                if (response && response.statusCode !== 200) return callback(response);
-
-                if (callback) {
+            if (!callback) {
+                return new Promise((resolve, reject) => {
+                  request(addProxy(opt), function (error, response, body) {
+                    if (error) return reject(error);
+                    if (response.statusCode !== 200) return reject(response);
                     const result = symbol ? JSON.parse(body) : bookPriceData(JSON.parse(body));
-                    return callback(null, result);
-                }
+                    return resolve(result);
+                  });
+                });
+            };
+            request(addProxy(opt), function (error, response, body) {
+                if (error) return callback(error);
+                if (response.statusCode !== 200) return callback(response);
+                const result = symbol ? JSON.parse(body) : bookPriceData(JSON.parse(body));
+                return callback(null, result);
             });
         },
 

--- a/node-binance-api.js
+++ b/node-binance-api.js
@@ -1437,7 +1437,7 @@ let api = function Binance() {
                     return resolve(result);
                   });
                 });
-            };
+            }
             request(addProxy(opt), function (error, response, body) {
                 if (error) return callback(error);
                 if (response.statusCode !== 200) return callback(response);

--- a/node-binance-api.js
+++ b/node-binance-api.js
@@ -1088,7 +1088,6 @@ let api = function Binance() {
             return this;
         },
 
-
         /**
         * Creates an order
         * @param {string} side - BUY or SELL
@@ -1104,9 +1103,9 @@ let api = function Binance() {
             return new Promise((resolve, reject) => {
               callback = (error, response) => {
                 if (error) {
-                  reject(error)
+                  reject(error);
                 } else {
-                  resolve(response)
+                  resolve(response);
                 }
               }
               order(side, symbol, quantity, price, flags, callback);
@@ -1126,7 +1125,20 @@ let api = function Binance() {
         * @return {undefined}
         */
         buy: function (symbol, quantity, price, flags = {}, callback = false) {
+          if (!callback) {
+            return new Promise((resolve, reject) => {
+              callback = (error, response) => {
+                if (error) {
+                  reject(error);
+                } else {
+                  resolve(response);
+                }
+              }
+              order('BUY', symbol, quantity, price, flags, callback);
+            })
+          } else {
             order('BUY', symbol, quantity, price, flags, callback);
+          }
         },
 
         /**
@@ -1139,7 +1151,21 @@ let api = function Binance() {
         * @return {undefined}
         */
         sell: function (symbol, quantity, price, flags = {}, callback = false) {
+          if (!callback) {
+            return new Promise((resolve, reject) => {
+              callback = (error, response) => {
+                if (error) {
+                  reject(error);
+                } else {
+                  resolve(response);
+                }
+              }
+              order('SELL', symbol, quantity, price, flags, callback);
+            })
+          } else {
             order('SELL', symbol, quantity, price, flags, callback);
+          }
+
         },
 
         /**
@@ -1156,7 +1182,20 @@ let api = function Binance() {
                 flags = { type: 'MARKET' };
             }
             if (typeof flags.type === 'undefined') flags.type = 'MARKET';
-            order('BUY', symbol, quantity, 0, flags, callback);
+            if (!callback) {
+              return new Promise((resolve, reject) => {
+                callback = (error, response) => {
+                  if (error) {
+                    reject(error);
+                  } else {
+                    resolve(response);
+                  }
+                }
+                order('BUY', symbol, quantity, 0, flags, callback);
+              })
+            } else {
+              order('BUY', symbol, quantity, 0, flags, callback);
+            }
         },
 
         /**
@@ -1173,7 +1212,20 @@ let api = function Binance() {
                 flags = { type: 'MARKET' };
             }
             if (typeof flags.type === 'undefined') flags.type = 'MARKET';
-            order('SELL', symbol, quantity, 0, flags, callback);
+            if (!callback) {
+              return new Promise((resolve, reject) => {
+                callback = (error, response) => {
+                  if (error) {
+                    reject(error);
+                  } else {
+                    resolve(response);
+                  }
+                }
+                order('SELL', symbol, quantity, 0, flags, callback);
+              })
+            } else {
+              order('SELL', symbol, quantity, 0, flags, callback);
+            }
         },
 
         /**
@@ -1184,9 +1236,24 @@ let api = function Binance() {
         * @return {undefined}
         */
         cancel: function (symbol, orderid, callback = false) {
+          if (!callback) {
+            return new Promise((resolve, reject) => {
+              callback = (error, response) => {
+                if (error) {
+                  reject(error);
+                } else {
+                  resolve(response);
+                }
+              }
+              signedRequest(base + 'v3/order', { symbol: symbol, orderId: orderid }, function (error, data) {
+                  return callback.call(this, error, data, symbol);
+              }, 'DELETE');
+            })
+          } else {
             signedRequest(base + 'v3/order', { symbol: symbol, orderId: orderid }, function (error, data) {
-                if (callback) return callback.call(this, error, data, symbol);
+                return callback.call(this, error, data, symbol);
             }, 'DELETE');
+          }
         },
 
         /**
@@ -1199,9 +1266,24 @@ let api = function Binance() {
         */
         orderStatus: function (symbol, orderid, callback, flags = {}) {
             let parameters = Object.assign({ symbol: symbol, orderId: orderid }, flags);
-            signedRequest(base + 'v3/order', parameters, function (error, data) {
-                if (callback) return callback.call(this, error, data, symbol);
-            });
+            if (!callback) {
+              return new Promise((resolve, reject) => {
+                callback = (error, response) => {
+                  if (error) {
+                    reject(error);
+                  } else {
+                    resolve(response);
+                  }
+                }
+                signedRequest(base + 'v3/order', parameters, function (error, data) {
+                    return callback.call(this, error, data, symbol);
+                });
+              })
+            } else {
+              signedRequest(base + 'v3/order', parameters, function (error, data) {
+                  return callback.call(this, error, data, symbol);
+              });
+            }
         },
 
         /**
@@ -1212,9 +1294,24 @@ let api = function Binance() {
         */
         openOrders: function (symbol, callback) {
             let parameters = symbol ? { symbol: symbol } : {};
-            signedRequest(base + 'v3/openOrders', parameters, function (error, data) {
-                return callback.call(this, error, data, symbol);
-            });
+            if (!callback) {
+              return new Promise((resolve, reject) => {
+                callback = (error, response) => {
+                  if (error) {
+                    reject(error);
+                  } else {
+                    resolve(response);
+                  }
+                }
+                signedRequest(base + 'v3/openOrders', parameters, function (error, data) {
+                    return callback.call(this, error, data, symbol);
+                });
+              })
+            } else {
+              signedRequest(base + 'v3/openOrders', parameters, function (error, data) {
+                  return callback.call(this, error, data, symbol);
+              });
+            }
         },
 
         /**
@@ -1224,18 +1321,42 @@ let api = function Binance() {
         * @return {undefined}
         */
         cancelOrders: function (symbol, callback = false) {
+          if (!callback) {
+            return new Promise((resolve, reject) => {
+              callback = (error, response) => {
+                if (error) {
+                  reject(error);
+                } else {
+                  resolve(response);
+                }
+              }
+              signedRequest(base + 'v3/openOrders', { symbol: symbol }, function (error, json) {
+                  if (json.length === 0) {
+                      return callback.call(this, 'No orders present for this symbol', {}, symbol);
+                  }
+                  for (let obj of json) {
+                      let quantity = obj.origQty - obj.executedQty;
+                      Binance.options.log('cancel order: ' + obj.side + ' ' + symbol + ' ' + quantity + ' @ ' + obj.price + ' #' + obj.orderId);
+                      signedRequest(base + 'v3/order', { symbol: symbol, orderId: obj.orderId }, function (error, data) {
+                          return callback.call(this, error, data, symbol);
+                      }, 'DELETE');
+                  }
+              });
+            })
+          } else {
             signedRequest(base + 'v3/openOrders', { symbol: symbol }, function (error, json) {
                 if (json.length === 0) {
-                    if (callback) return callback.call(this, 'No orders present for this symbol', {}, symbol);
+                    return callback.call(this, 'No orders present for this symbol', {}, symbol);
                 }
                 for (let obj of json) {
                     let quantity = obj.origQty - obj.executedQty;
                     Binance.options.log('cancel order: ' + obj.side + ' ' + symbol + ' ' + quantity + ' @ ' + obj.price + ' #' + obj.orderId);
                     signedRequest(base + 'v3/order', { symbol: symbol, orderId: obj.orderId }, function (error, data) {
-                        if (callback) return callback.call(this, error, data, symbol);
+                        return callback.call(this, error, data, symbol);
                     }, 'DELETE');
                 }
             });
+          }
         },
 
         /**
@@ -1247,9 +1368,24 @@ let api = function Binance() {
         */
         allOrders: function (symbol, callback, options = {}) {
             let parameters = Object.assign({ symbol: symbol }, options);
-            signedRequest(base + 'v3/allOrders', parameters, function (error, data) {
-                if (callback) return callback.call(this, error, data, symbol);
-            });
+            if (!callback) {
+              return new Promise((resolve, reject) => {
+                callback = (error, response) => {
+                  if (error) {
+                    reject(error);
+                  } else {
+                    resolve(response);
+                  }
+                }
+                signedRequest(base + 'v3/allOrders', parameters, function (error, data) {
+                    return callback.call(this, error, data, symbol);
+                });
+              })
+            } else {
+              signedRequest(base + 'v3/allOrders', parameters, function (error, data) {
+                  return callback.call(this, error, data, symbol);
+              });
+            }
         },
 
         /**
@@ -1260,9 +1396,24 @@ let api = function Binance() {
         * @return {undefined}
         */
         depth: function (symbol, callback, limit = 100) {
+          if (!callback) {
+            return new Promise((resolve, reject) => {
+              callback = (error, response) => {
+                if (error) {
+                  reject(error);
+                } else {
+                  resolve(response);
+                }
+              }
+              publicRequest(base + 'v1/depth', { symbol: symbol, limit: limit }, function (error, data) {
+                  return callback.call(this, error, depthData(data), symbol);
+              });
+            })
+          } else {
             publicRequest(base + 'v1/depth', { symbol: symbol, limit: limit }, function (error, data) {
                 return callback.call(this, error, depthData(data), symbol);
             });
+          }
         },
 
         /**
@@ -1335,7 +1486,6 @@ let api = function Binance() {
         bookTickers: function (symbol, callback) {
             const params = typeof symbol === 'string' ? '?symbol=' + symbol : '';
             if (typeof symbol === 'function') callback = symbol; // backwards compatibility
-
             let opt = {
                 url: base + 'v3/ticker/bookTicker' + params,
                 timeout: Binance.options.recvWindow
@@ -1366,9 +1516,24 @@ let api = function Binance() {
         */
         prevDay: function (symbol, callback) {
             let input = symbol ? { symbol: symbol } : {};
-            publicRequest(base + 'v1/ticker/24hr', input, function (error, data) {
-                if (callback) return callback.call(this, error, data, symbol);
-            });
+            if (!callback) {
+              return new Promise((resolve, reject) => {
+                callback = (error, response) => {
+                  if (error) {
+                    reject(error);
+                  } else {
+                    resolve(response);
+                  }
+                }
+                publicRequest(base + 'v1/ticker/24hr', input, function (error, data) {
+                    return callback.call(this, error, data, symbol);
+                });
+              })
+            } else {
+              publicRequest(base + 'v1/ticker/24hr', input, function (error, data) {
+                  return callback.call(this, error, data, symbol);
+              });
+            }
         },
 
         /**
@@ -1377,23 +1542,64 @@ let api = function Binance() {
         * @return {undefined}
         */
         exchangeInfo: function (callback) {
+          if (!callback) {
+            return new Promise((resolve, reject) => {
+              callback = (error, response) => {
+                if (error) {
+                  reject(error);
+                } else {
+                  resolve(response);
+                }
+              }
+              publicRequest(base + 'v1/exchangeInfo', {}, callback);
+            })
+          } else {
             publicRequest(base + 'v1/exchangeInfo', {}, callback);
+          }
         },
+
         /**
         * Gets the dust log for user
         * @param {function} callback - the callback function
         * @return {undefined}
         */
         dustLog: function (callback) {
-          signedRequest(wapi + '/v3/userAssetDribbletLog.html', {}, callback);
+          if (!callback) {
+            return new Promise((resolve, reject) => {
+              callback = (error, response) => {
+                if (error) {
+                  reject(error);
+                } else {
+                  resolve(response);
+                }
+              }
+              signedRequest(wapi + '/v3/userAssetDribbletLog.html', {}, callback);
+            })
+          } else {
+            signedRequest(wapi + '/v3/userAssetDribbletLog.html', {}, callback);
+          }
         },
+
         /**
         * Gets the the system status
         * @param {function} callback - the callback function
         * @return {undefined}
         */
         systemStatus: function (callback) {
+          if (!callback) {
+            return new Promise((resolve, reject) => {
+              callback = (error, response) => {
+                if (error) {
+                  reject(error);
+                } else {
+                  resolve(response);
+                }
+              }
+              publicRequest(wapi + 'v3/systemStatus.html', {}, callback);
+            })
+          } else {
             publicRequest(wapi + 'v3/systemStatus.html', {}, callback);
+          }
         },
 
         /**
@@ -1409,7 +1615,20 @@ let api = function Binance() {
             let params = { asset, address, amount };
             params.name = 'API Withdraw';
             if (addressTag) params.addressTag = addressTag;
-            signedRequest(wapi + 'v3/withdraw.html', params, callback, 'POST');
+            if (!callback) {
+              return new Promise((resolve, reject) => {
+                callback = (error, response) => {
+                  if (error) {
+                    reject(error);
+                  } else {
+                    resolve(response);
+                  }
+                }
+                signedRequest(wapi + 'v3/withdraw.html', params, callback, 'POST');
+              })
+            } else {
+              signedRequest(wapi + 'v3/withdraw.html', params, callback, 'POST');
+            }
         },
 
         /**
@@ -1420,7 +1639,20 @@ let api = function Binance() {
         */
         withdrawHistory: function (callback, params = {}) {
             if (typeof params === 'string') params = { asset: params };
-            signedRequest(wapi + 'v3/withdrawHistory.html', params, callback);
+            if (!callback) {
+              return new Promise((resolve, reject) => {
+                callback = (error, response) => {
+                  if (error) {
+                    reject(error);
+                  } else {
+                    resolve(response);
+                  }
+                }
+                signedRequest(wapi + 'v3/withdrawHistory.html', params, callback);
+              })
+            } else {
+              signedRequest(wapi + 'v3/withdrawHistory.html', params, callback);
+            }
         },
 
         /**
@@ -1431,7 +1663,20 @@ let api = function Binance() {
         */
         depositHistory: function (callback, params = {}) {
             if (typeof params === 'string') params = { asset: params }; // Support 'asset' (string) or optional parameters (object)
-            signedRequest(wapi + 'v3/depositHistory.html', params, callback);
+            if (!callback) {
+              return new Promise((resolve, reject) => {
+                callback = (error, response) => {
+                  if (error) {
+                    reject(error);
+                  } else {
+                    resolve(response);
+                  }
+                }
+                signedRequest(wapi + 'v3/depositHistory.html', params, callback);
+              })
+            } else {
+              signedRequest(wapi + 'v3/depositHistory.html', params, callback);
+            }
         },
 
         /**
@@ -1441,7 +1686,20 @@ let api = function Binance() {
         * @return {undefined}
         */
         depositAddress: function (asset, callback) {
+          if (!callback) {
+            return new Promise((resolve, reject) => {
+              callback = (error, response) => {
+                if (error) {
+                  reject(error);
+                } else {
+                  resolve(response);
+                }
+              }
+              signedRequest(wapi + 'v3/depositAddress.html', { asset: asset }, callback);
+            })
+          } else {
             signedRequest(wapi + 'v3/depositAddress.html', { asset: asset }, callback);
+          }
         },
 
         /**
@@ -1450,7 +1708,20 @@ let api = function Binance() {
         * @return {undefined}
         */
         accountStatus: function (callback) {
+          if (!callback) {
+            return new Promise((resolve, reject) => {
+              callback = (error, response) => {
+                if (error) {
+                  reject(error);
+                } else {
+                  resolve(response);
+                }
+              }
+              signedRequest(wapi + 'v3/accountStatus.html', {}, callback);
+            })
+          } else {
             signedRequest(wapi + 'v3/accountStatus.html', {}, callback);
+          }
         },
 
         /**
@@ -1461,7 +1732,20 @@ let api = function Binance() {
         */
         tradeFee: function (callback, symbol = false) {
             let params = symbol ? { symbol: symbol } : {};
-            signedRequest(wapi + 'v3/tradeFee.html', params, callback);
+            if (!callback) {
+              return new Promise((resolve, reject) => {
+                callback = (error, response) => {
+                  if (error) {
+                    reject(error);
+                  } else {
+                    resolve(response);
+                  }
+                }
+                signedRequest(wapi + 'v3/tradeFee.html', params, callback);
+              })
+            } else {
+              signedRequest(wapi + 'v3/tradeFee.html', params, callback);
+            }
         },
 
         /**
@@ -1470,7 +1754,20 @@ let api = function Binance() {
         * @return {undefined}
         */
         assetDetail: function (callback) {
+          if (!callback) {
+            return new Promise((resolve, reject) => {
+              callback = (error, response) => {
+                if (error) {
+                  reject(error);
+                } else {
+                  resolve(response);
+                }
+              }
+              signedRequest(wapi + 'v3/assetDetail.html', {}, callback);
+            })
+          } else {
             signedRequest(wapi + 'v3/assetDetail.html', {}, callback);
+          }
         },
 
         /**
@@ -1479,7 +1776,20 @@ let api = function Binance() {
         * @return {undefined}
         */
         account: function (callback) {
+          if (!callback) {
+            return new Promise((resolve, reject) => {
+              callback = (error, response) => {
+                if (error) {
+                  reject(error);
+                } else {
+                  resolve(response);
+                }
+              }
+              signedRequest(base + 'v3/account', {}, callback);
+            })
+          } else {
             signedRequest(base + 'v3/account', {}, callback);
+          }
         },
 
         /**
@@ -1488,9 +1798,24 @@ let api = function Binance() {
         * @return {undefined}
         */
         balance: function (callback) {
+          if (!callback) {
+            return new Promise((resolve, reject) => {
+              callback = (error, response) => {
+                if (error) {
+                  reject(error);
+                } else {
+                  resolve(response);
+                }
+              }
+              signedRequest(base + 'v3/account', {}, function (error, data) {
+                  callback(error, balanceData(data));
+              });
+            })
+          } else {
             signedRequest(base + 'v3/account', {}, function (error, data) {
-                if (callback) callback(error, balanceData(data));
+                callback(error, balanceData(data));
             });
+          }
         },
 
         /**
@@ -1502,9 +1827,24 @@ let api = function Binance() {
         */
         trades: function (symbol, callback, options = {}) {
             let parameters = Object.assign({ symbol: symbol }, options);
-            signedRequest(base + 'v3/myTrades', parameters, function (error, data) {
-                if (callback) return callback.call(this, error, data, symbol);
-            });
+            if (!callback) {
+              return new Promise((resolve, reject) => {
+                callback = (error, response) => {
+                  if (error) {
+                    reject(error);
+                  } else {
+                    resolve(response);
+                  }
+                }
+                signedRequest(base + 'v3/myTrades', parameters, function (error, data) {
+                    return callback.call(this, error, data, symbol);
+                });
+              })
+            } else {
+              signedRequest(base + 'v3/myTrades', parameters, function (error, data) {
+                  return callback.call(this, error, data, symbol);
+              });
+            }
         },
 
         /**
@@ -1513,11 +1853,28 @@ let api = function Binance() {
         * @return {undefined}
         */
         useServerTime: function (callback = false) {
+          if (!callback) {
+            return new Promise((resolve, reject) => {
+              callback = (error, response) => {
+                if (error) {
+                  reject(error);
+                } else {
+                  resolve(response);
+                }
+              }
+              apiRequest(base + 'v1/time', {}, function (error, response) {
+                  Binance.info.timeOffset = response.serverTime - new Date().getTime();
+                  //Binance.options.log("server time set: ", response.serverTime, Binance.info.timeOffset);
+                  callback(error, response);
+              });
+            })
+          } else {
             apiRequest(base + 'v1/time', {}, function (error, response) {
                 Binance.info.timeOffset = response.serverTime - new Date().getTime();
                 //Binance.options.log("server time set: ", response.serverTime, Binance.info.timeOffset);
-                if (callback) callback();
+                callback(error, response);
             });
+          }
         },
 
         /**
@@ -1526,7 +1883,20 @@ let api = function Binance() {
         * @return {undefined}
         */
         time: function (callback) {
+          if (!callback) {
+            return new Promise((resolve, reject) => {
+              callback = (error, response) => {
+                if (error) {
+                  reject(error);
+                } else {
+                  resolve(response);
+                }
+              }
+              apiRequest(base + 'v1/time', {}, callback);
+            })
+          } else {
             apiRequest(base + 'v1/time', {}, callback);
+          }
         },
 
         /**
@@ -1538,7 +1908,20 @@ let api = function Binance() {
         */
         aggTrades: function (symbol, options = {}, callback = false) { //fromId startTime endTime limit
             let parameters = Object.assign({ symbol }, options);
-            marketRequest(base + 'v1/aggTrades', parameters, callback);
+            if (!callback) {
+              return new Promise((resolve, reject) => {
+                callback = (error, response) => {
+                  if (error) {
+                    reject(error);
+                  } else {
+                    resolve(response);
+                  }
+                }
+                marketRequest(base + 'v1/aggTrades', parameters, callback);
+              })
+            } else {
+              marketRequest(base + 'v1/aggTrades', parameters, callback);
+            }
         },
 
         /**
@@ -1549,7 +1932,20 @@ let api = function Binance() {
         * @return {undefined}
         */
         recentTrades: function (symbol, callback, limit = 500) {
+          if (!callback) {
+            return new Promise((resolve, reject) => {
+              callback = (error, response) => {
+                if (error) {
+                  reject(error);
+                } else {
+                  resolve(response);
+                }
+              }
+              marketRequest(base + 'v1/trades', { symbol: symbol, limit: limit }, callback);
+            })
+          } else {
             marketRequest(base + 'v1/trades', { symbol: symbol, limit: limit }, callback);
+          }
         },
 
         /**
@@ -1563,7 +1959,20 @@ let api = function Binance() {
         historicalTrades: function (symbol, callback, limit = 500, fromId = false) {
             let parameters = { symbol: symbol, limit: limit };
             if (fromId) parameters.fromId = fromId;
-            marketRequest(base + 'v1/historicalTrades', parameters, callback);
+            if (!callback) {
+              return new Promise((resolve, reject) => {
+                callback = (error, response) => {
+                  if (error) {
+                    reject(error);
+                  } else {
+                    resolve(response);
+                  }
+                }
+                marketRequest(base + 'v1/historicalTrades', parameters, callback);
+              })
+            } else {
+              marketRequest(base + 'v1/historicalTrades', parameters, callback);
+            }
         },
 
         /**
@@ -1617,11 +2026,25 @@ let api = function Binance() {
         * @return {undefined}
         */
         candlesticks: function (symbol, interval = '5m', callback = false, options = { limit: 500 }) {
-            if (!callback) return;
             let params = Object.assign({ symbol: symbol, interval: interval }, options);
-            publicRequest(base + 'v1/klines', params, function (error, data) {
-                return callback.call(this, error, data, symbol);
-            });
+            if (!callback) {
+              return new Promise((resolve, reject) => {
+                callback = (error, response) => {
+                  if (error) {
+                    reject(error);
+                  } else {
+                    resolve(response);
+                  }
+                }
+                publicRequest(base + 'v1/klines', params, function (error, data) {
+                    return callback.call(this, error, data, symbol);
+                });
+              })
+            } else {
+              publicRequest(base + 'v1/klines', params, function (error, data) {
+                  return callback.call(this, error, data, symbol);
+              });
+            }
         },
 
         /**
@@ -1633,7 +2056,20 @@ let api = function Binance() {
         * @return {undefined}
         */
         publicRequest: function (url, data, callback, method = 'GET') {
-            publicRequest(url, data, callback, method)
+          if (!callback) {
+            return new Promise((resolve, reject) => {
+              callback = (error, response) => {
+                if (error) {
+                  reject(error);
+                } else {
+                  resolve(response);
+                }
+              }
+              publicRequest(url, data, callback, method);
+            })
+          } else {
+            publicRequest(url, data, callback, method);
+          }
         },
 
         /**
@@ -1645,7 +2081,20 @@ let api = function Binance() {
         * @return {undefined}
         */
         signedRequest: function (url, data, callback, method = 'GET') {
+          if (!callback) {
+            return new Promise((resolve, reject) => {
+              callback = (error, response) => {
+                if (error) {
+                  reject(error);
+                } else {
+                  resolve(response);
+                }
+              }
+              signedRequest(url, data, callback, method);
+            })
+          } else {
             signedRequest(url, data, callback, method);
+          }
         },
 
         /**
@@ -1665,6 +2114,7 @@ let api = function Binance() {
             else if (symbol.substr(-4) === 'USDS') return 'USDS';
             else if (symbol.substr(-4) === 'TUSD') return 'TUSD';
         },
+
         websockets: {
             /**
             * Userdata websockets function

--- a/node-binance-api.js
+++ b/node-binance-api.js
@@ -1096,7 +1096,7 @@ let api = function Binance() {
         * @param {numeric} price - the price to pay for each unit
         * @param {object} flags - aadditionalbuy order flags
         * @param {function} callback - the callback function
-        * @return {undefined}
+        * @return {promise or undefined} - omitting the callback returns a promise
         */
         order: function (side, symbol, quantity, price, flags = {}, callback = false) {
           if (!callback) {
@@ -1122,7 +1122,7 @@ let api = function Binance() {
         * @param {numeric} price - the price to pay for each unit
         * @param {object} flags - additional buy order flags
         * @param {function} callback - the callback function
-        * @return {undefined}
+        * @return {promise or undefined} - omitting the callback returns a promise
         */
         buy: function (symbol, quantity, price, flags = {}, callback = false) {
           if (!callback) {
@@ -1148,7 +1148,7 @@ let api = function Binance() {
         * @param {numeric} price - the price to sell each unit for
         * @param {object} flags - additional order flags
         * @param {function} callback - the callback function
-        * @return {undefined}
+        * @return {promise or undefined} - omitting the callback returns a promise
         */
         sell: function (symbol, quantity, price, flags = {}, callback = false) {
           if (!callback) {
@@ -1174,7 +1174,7 @@ let api = function Binance() {
         * @param {numeric} quantity - the quantity required
         * @param {object} flags - additional buy order flags
         * @param {function} callback - the callback function
-        * @return {undefined}
+        * @return {promise or undefined} - omitting the callback returns a promise
         */
         marketBuy: function (symbol, quantity, flags = { type: 'MARKET' }, callback = false) {
             if (typeof flags === 'function') { // Accept callback as third parameter
@@ -1204,7 +1204,7 @@ let api = function Binance() {
         * @param {numeric} quantity - the quantity required
         * @param {object} flags - additional sell order flags
         * @param {function} callback - the callback function
-        * @return {undefined}
+        * @return {promise or undefined} - omitting the callback returns a promise
         */
         marketSell: function (symbol, quantity, flags = { type: 'MARKET' }, callback = false) {
             if (typeof flags === 'function') { // Accept callback as third parameter
@@ -1233,7 +1233,7 @@ let api = function Binance() {
         * @param {string} symbol - the symbol to cancel
         * @param {string} orderid - the orderid to cancel
         * @param {function} callback - the callback function
-        * @return {undefined}
+        * @return {promise or undefined} - omitting the callback returns a promise
         */
         cancel: function (symbol, orderid, callback = false) {
           if (!callback) {
@@ -1262,7 +1262,7 @@ let api = function Binance() {
         * @param {string} orderid - the orderid to check
         * @param {function} callback - the callback function
         * @param {object} flags - any additional flags
-        * @return {undefined}
+        * @return {promise or undefined} - omitting the callback returns a promise
         */
         orderStatus: function (symbol, orderid, callback, flags = {}) {
             let parameters = Object.assign({ symbol: symbol, orderId: orderid }, flags);
@@ -1290,7 +1290,7 @@ let api = function Binance() {
         * Gets open orders
         * @param {string} symbol - the symbol to get
         * @param {function} callback - the callback function
-        * @return {undefined}
+        * @return {promise or undefined} - omitting the callback returns a promise
         */
         openOrders: function (symbol, callback) {
             let parameters = symbol ? { symbol: symbol } : {};
@@ -1318,7 +1318,7 @@ let api = function Binance() {
         * Cancels all order of a given symbol
         * @param {string} symbol - the symbol to cancel all orders for
         * @param {function} callback - the callback function
-        * @return {undefined}
+        * @return {promise or undefined} - omitting the callback returns a promise
         */
         cancelOrders: function (symbol, callback = false) {
           if (!callback) {
@@ -1364,7 +1364,7 @@ let api = function Binance() {
         * @param {string} symbol - the symbol
         * @param {function} callback - the callback function
         * @param {object} options - additional options
-        * @return {undefined}
+        * @return {promise or undefined} - omitting the callback returns a promise
         */
         allOrders: function (symbol, callback, options = {}) {
             let parameters = Object.assign({ symbol: symbol }, options);
@@ -1393,7 +1393,7 @@ let api = function Binance() {
         * @param {string} symbol - the symbol
         * @param {function} callback - the callback function
         * @param {int} limit - limit the number of returned orders
-        * @return {undefined}
+        * @return {promise or undefined} - omitting the callback returns a promise
         */
         depth: function (symbol, callback, limit = 100) {
           if (!callback) {
@@ -1420,7 +1420,7 @@ let api = function Binance() {
         * Gets the average prices of a given symbol
         * @param {string} symbol - the symbol
         * @param {function} callback - the callback function
-        * @return {undefined}
+        * @return {promise or undefined} - omitting the callback returns a promise
         */
         avgPrice: function (symbol, callback = false) {
             let opt = {
@@ -1451,7 +1451,7 @@ let api = function Binance() {
         * Gets the prices of a given symbol(s)
         * @param {string} symbol - the symbol
         * @param {function} callback - the callback function
-        * @return {undefined}
+        * @return {promise or undefined} - omitting the callback returns a promise
         */
         prices: function (symbol, callback = false) {
             const params = typeof symbol === 'string' ? '?symbol=' + symbol : '';
@@ -1481,7 +1481,7 @@ let api = function Binance() {
         * Gets the book tickers of given symbol(s)
         * @param {string} symbol - the symbol
         * @param {function} callback - the callback function
-        * @return {undefined}
+        * @return {promise or undefined} - omitting the callback returns a promise
         */
         bookTickers: function (symbol, callback) {
             const params = typeof symbol === 'string' ? '?symbol=' + symbol : '';
@@ -1512,7 +1512,7 @@ let api = function Binance() {
         * Gets the prevday percentage change
         * @param {string} symbol - the symbol or symbols
         * @param {function} callback - the callback function
-        * @return {undefined}
+        * @return {promise or undefined} - omitting the callback returns a promise
         */
         prevDay: function (symbol, callback) {
             let input = symbol ? { symbol: symbol } : {};
@@ -1539,7 +1539,7 @@ let api = function Binance() {
         /**
         * Gets the the exchange info
         * @param {function} callback - the callback function
-        * @return {undefined}
+        * @return {promise or undefined} - omitting the callback returns a promise
         */
         exchangeInfo: function (callback) {
           if (!callback) {
@@ -1561,7 +1561,7 @@ let api = function Binance() {
         /**
         * Gets the dust log for user
         * @param {function} callback - the callback function
-        * @return {undefined}
+        * @return {promise or undefined} - omitting the callback returns a promise
         */
         dustLog: function (callback) {
           if (!callback) {
@@ -1583,7 +1583,7 @@ let api = function Binance() {
         /**
         * Gets the the system status
         * @param {function} callback - the callback function
-        * @return {undefined}
+        * @return {promise or undefined} - omitting the callback returns a promise
         */
         systemStatus: function (callback) {
           if (!callback) {
@@ -1609,7 +1609,7 @@ let api = function Binance() {
         * @param {number} amount - the amount to transfer
         * @param {string} addressTag - and addtional address tag
         * @param {function} callback - the callback function
-        * @return {undefined}
+        * @return {promise or undefined} - omitting the callback returns a promise
         */
         withdraw: function (asset, address, amount, addressTag = false, callback = false) {
             let params = { asset, address, amount };
@@ -1635,7 +1635,7 @@ let api = function Binance() {
         * Get the Withdraws history for a given asset
         * @param {function} callback - the callback function
         * @param {object} params - supports limit and fromId parameters
-        * @return {undefined}
+        * @return {promise or undefined} - omitting the callback returns a promise
         */
         withdrawHistory: function (callback, params = {}) {
             if (typeof params === 'string') params = { asset: params };
@@ -1659,7 +1659,7 @@ let api = function Binance() {
         * Get the deposit history
         * @param {function} callback - the callback function
         * @param {object} params - additional params
-        * @return {undefined}
+        * @return {promise or undefined} - omitting the callback returns a promise
         */
         depositHistory: function (callback, params = {}) {
             if (typeof params === 'string') params = { asset: params }; // Support 'asset' (string) or optional parameters (object)
@@ -1683,7 +1683,7 @@ let api = function Binance() {
         * Get the deposit history for given asset
         * @param {string} asset - the asset
         * @param {function} callback - the callback function
-        * @return {undefined}
+        * @return {promise or undefined} - omitting the callback returns a promise
         */
         depositAddress: function (asset, callback) {
           if (!callback) {
@@ -1705,7 +1705,7 @@ let api = function Binance() {
         /**
         * Get the account status
         * @param {function} callback - the callback function
-        * @return {undefined}
+        * @return {promise or undefined} - omitting the callback returns a promise
         */
         accountStatus: function (callback) {
           if (!callback) {
@@ -1728,7 +1728,7 @@ let api = function Binance() {
         * Get the trade fee
         * @param {function} callback - the callback function
         * @param {string} symbol (optional)
-        * @return {undefined}
+        * @return {promise or undefined} - omitting the callback returns a promise
         */
         tradeFee: function (callback, symbol = false) {
             let params = symbol ? { symbol: symbol } : {};
@@ -1751,7 +1751,7 @@ let api = function Binance() {
         /**
         * Fetch asset detail (minWithdrawAmount, depositStatus, withdrawFee, withdrawStatus, depositTip)
         * @param {function} callback - the callback function
-        * @return {undefined}
+        * @return {promise or undefined} - omitting the callback returns a promise
         */
         assetDetail: function (callback) {
           if (!callback) {
@@ -1773,7 +1773,7 @@ let api = function Binance() {
         /**
         * Get the account
         * @param {function} callback - the callback function
-        * @return {undefined}
+        * @return {promise or undefined} - omitting the callback returns a promise
         */
         account: function (callback) {
           if (!callback) {
@@ -1795,7 +1795,7 @@ let api = function Binance() {
         /**
         * Get the balance data
         * @param {function} callback - the callback function
-        * @return {undefined}
+        * @return {promise or undefined} - omitting the callback returns a promise
         */
         balance: function (callback) {
           if (!callback) {
@@ -1823,7 +1823,7 @@ let api = function Binance() {
         * @param {string} symbol - the symbol
         * @param {function} callback - the callback function
         * @param {object} options - additional options
-        * @return {undefined}
+        * @return {promise or undefined} - omitting the callback returns a promise
         */
         trades: function (symbol, callback, options = {}) {
             let parameters = Object.assign({ symbol: symbol }, options);
@@ -1850,7 +1850,7 @@ let api = function Binance() {
         /**
         * Tell api to use the server time to offset time indexes
         * @param {function} callback - the callback function
-        * @return {undefined}
+        * @return {promise or undefined} - omitting the callback returns a promise
         */
         useServerTime: function (callback = false) {
           if (!callback) {
@@ -1880,7 +1880,7 @@ let api = function Binance() {
         /**
         * Gets the time
         * @param {function} callback - the callback function
-        * @return {undefined}
+        * @return {promise or undefined} - omitting the callback returns a promise
         */
         time: function (callback) {
           if (!callback) {
@@ -1904,7 +1904,7 @@ let api = function Binance() {
         * @param {string} symbol - the symbol
         * @param {object} options - addtional optoins
         * @param {function} callback - the callback function
-        * @return {undefined}
+        * @return {promise or undefined} - omitting the callback returns a promise
         */
         aggTrades: function (symbol, options = {}, callback = false) { //fromId startTime endTime limit
             let parameters = Object.assign({ symbol }, options);
@@ -1929,7 +1929,7 @@ let api = function Binance() {
         * @param {string} symbol - the symbol
         * @param {function} callback - the callback function
         * @param {int} limit - limit the number of items returned
-        * @return {undefined}
+        * @return {promise or undefined} - omitting the callback returns a promise
         */
         recentTrades: function (symbol, callback, limit = 500) {
           if (!callback) {
@@ -1954,7 +1954,7 @@ let api = function Binance() {
         * @param {function} callback - the callback function
         * @param {int} limit - limit the number of items returned
         * @param {int} fromId - from this id
-        * @return {undefined}
+        * @return {promise or undefined} - omitting the callback returns a promise
         */
         historicalTrades: function (symbol, callback, limit = 500, fromId = false) {
             let parameters = { symbol: symbol, limit: limit };
@@ -2023,7 +2023,7 @@ let api = function Binance() {
         * @param {function} interval - the callback function
         * @param {function} callback - the callback function
         * @param {object} options - additional options
-        * @return {undefined}
+        * @return {promise or undefined} - omitting the callback returns a promise
         */
         candlesticks: function (symbol, interval = '5m', callback = false, options = { limit: 500 }) {
             let params = Object.assign({ symbol: symbol, interval: interval }, options);
@@ -2053,7 +2053,7 @@ let api = function Binance() {
         * @param {object} data - the data to send
         * @param {function} callback - the callback function
         * @param {string} method - the http method
-        * @return {undefined}
+        * @return {promise or undefined} - omitting the callback returns a promise
         */
         publicRequest: function (url, data, callback, method = 'GET') {
           if (!callback) {
@@ -2078,7 +2078,7 @@ let api = function Binance() {
         * @param {object} data - the data to send
         * @param {function} callback - the callback function
         * @param {string} method - the http method
-        * @return {undefined}
+        * @return {promise or undefined} - omitting the callback returns a promise
         */
         signedRequest: function (url, data, callback, method = 'GET') {
           if (!callback) {

--- a/node-binance-api.js
+++ b/node-binance-api.js
@@ -374,9 +374,9 @@ let api = function Binance() {
     /**
      * Used to subscribe to a single websocket endpoint
      * @param {string} endpoint - endpoint to connect to
-     * @param {function} callback - the function to called when information is received
+     * @param {function} callback - the function to call when information is received
      * @param {boolean} reconnect - whether to reconnect on disconnect
-     * @param {object} opened_callback - the function to called when opened
+     * @param {object} opened_callback - the function to call when opened
      * @return {WebSocket} - websocket reference
      */
     const subscribe = function (endpoint, callback, reconnect = false, opened_callback = false) {
@@ -424,9 +424,9 @@ let api = function Binance() {
     /**
      * Used to subscribe to a combined websocket endpoint
      * @param {string} streams - streams to connect to
-     * @param {function} callback - the function to called when information is received
+     * @param {function} callback - the function to call when information is received
      * @param {boolean} reconnect - whether to reconnect on disconnect
-     * @param {object} opened_callback - the function to called when opened
+     * @param {object} opened_callback - the function to call when opened
      * @return {WebSocket} - websocket reference
      */
     const subscribeCombined = function (streams, callback, reconnect = false, opened_callback = false) {
@@ -1469,7 +1469,7 @@ let api = function Binance() {
                     return resolve(priceData(JSON.parse(body)));
                   });
                 });
-            };
+            }
             request(addProxy(opt), function (error, response, body) {
                 if (error) return callback(error);
                 if (response.statusCode !== 200) return callback(response);

--- a/node-binance-api.js
+++ b/node-binance-api.js
@@ -1100,12 +1100,20 @@ let api = function Binance() {
         * @return {undefined}
         */
         order: function (side, symbol, quantity, price, flags = {}, callback = false) {
-            if (!callback) {
-              return new Promise((resolve, reject) => {
-                order(side, symbol, quantity, price, flags, callback);
-              })
-            }
+          if (!callback) {
+            return new Promise((resolve, reject) => {
+              callback = (error, response) => {
+                if (error) {
+                  reject(error)
+                } else {
+                  resolve(response)
+                }
+              }
+              order(side, symbol, quantity, price, flags, callback);
+            })
+          } else {
             order(side, symbol, quantity, price, flags, callback);
+          }
         },
 
         /**

--- a/node-binance-api.js
+++ b/node-binance-api.js
@@ -1100,6 +1100,11 @@ let api = function Binance() {
         * @return {undefined}
         */
         order: function (side, symbol, quantity, price, flags = {}, callback = false) {
+            if (!callback) {
+              return new Promise((resolve, reject) => {
+                order(side, symbol, quantity, price, flags, callback);
+              })
+            }
             order(side, symbol, quantity, price, flags, callback);
         },
 

--- a/node-binance-api.js
+++ b/node-binance-api.js
@@ -1658,7 +1658,12 @@ let api = function Binance() {
             if (substring === 'BTC') return 'BTC';
             else if (substring === 'ETH') return 'ETH';
             else if (substring === 'BNB') return 'BNB';
+            else if (substring === 'XRP') return 'XRP';
+            else if (substring === 'PAX') return 'PAX';
             else if (symbol.substr(-4) === 'USDT') return 'USDT';
+            else if (symbol.substr(-4) === 'USDC') return 'USDC';
+            else if (symbol.substr(-4) === 'USDS') return 'USDS';
+            else if (symbol.substr(-4) === 'TUSD') return 'TUSD';
         },
         websockets: {
             /**


### PR DESCRIPTION
Hi!
I've been working with your library for a while, as I was hooking it up to my high-frequency autonomous trading bot. Due to the complexity of my project, I prefer using the newer `async` / `await` syntax to increase maintainability by avoiding nested callbacks. It would have probably been better to re-write the library by using axios, but I found a solution that should not break functionality for any dependants of the library nor impact performance. Admittedly, the code size has increased, but I don't think I could have further optimized much of the added code. 
Keeping the old functionality intact, merging should not break functionality for anyone. The feature I've added is the ability to use `.then()` / `.catch()` and `async` / `await` syntax when calling any of the functions that make an API request. In order to minimize meddling with the current code structure, I've decided to return a promise whenever a callback isn't passed to a function that interacts with the API endpoint.

Please take a look at an [example](https://github.com/eluvade/node-binance-api/blob/master/examples/advanced.md#asynchronous-syntax-options) of calling the same `node-binance-api` function with three different syntaxes.

However, my work isn't entirely done. I have not touched the functions belonging to the websockets object. Before I commit any more work, I'd like to get some input from you to see whether this feature is something you'd like in the first place. I'm aware you're no longer maintaining the repository regularly, so I'll try not troubling you any further. But in case you'd like to reach me, here's my e-mail:  bunny.eluvade@gmail.com

Have a great day!

TL;DR Promisified functions that make API requests while still allowing to use regular callbacks instead.