### PR TITLE
added a 'localAddress' option to specify which IP is to be used for r…

### DIFF
--- a/node-binance-api.js
+++ b/node-binance-api.js
@@ -42,7 +42,8 @@ let api = function Binance() {
         reconnect: true,
         verbose: false,
         test: false,
-        log: function (...args) {
+        localAddress: '127.0.0.1',
+	log: function (...args) {
             console.log(Array.prototype.slice.call(args));
         }
     };
@@ -122,7 +123,8 @@ let api = function Binance() {
             'User-Agent': userAgent,
             'Content-type': contentType,
             'X-MBX-APIKEY': key || ''
-        }
+        },
+	localAddress: Binance.options.localAddress
     })
     const reqObjPOST = (url, data = {}, method = 'POST', key) => ({
         url: url,
@@ -1078,7 +1080,8 @@ let api = function Binance() {
             if (typeof Binance.options.test === 'undefined') Binance.options.test = default_options.test;
             if (typeof Binance.options.log === 'undefined') Binance.options.log = default_options.log;
             if (typeof Binance.options.verbose === 'undefined') Binance.options.verbose = default_options.verbose;
-            if (Binance.options.useServerTime) {
+            if (typeof Binance.options.localAddress === 'undefined') Binance.options.localAddress = default_options.localAddress;
+	    if (Binance.options.useServerTime) {
                 apiRequest(base + 'v1/time', {}, function (error, response) {
                     Binance.info.timeOffset = response.serverTime - new Date().getTime();
                     //Binance.options.log("server time set: ", response.serverTime, Binance.info.timeOffset);


### PR DESCRIPTION
I added a 'localAddress' option to specify which IP is to be used for requests to Binance API (allows the use of multi IP on a single server).

Usage : 
```
const binance = require('node-binance-api')().options({
  localAddress: '94.23.25.209',
  APIKEY: '<key>',
  APISECRET: '<secret>',
  useServerTime: true // If you get timestamp errors, synchronize to server time at startup
});
```

All requests will then use the IP given by localAddress ('94.23.25.209' in the example above). You can then run say 10 bots on a single server, with 10 different IPs. 

Why do that? Because Binance has API usage limits for IPs. Use several IPs thus allows to trade more, or to run different strategies and bots simultaneously with each one having the full usage limits for its IP. See https://www.binance.com/en/support/articles/360004492232

Of course you need to own the IPs you specify in the 'localAddress' parameter and have them configured on your server.

Works well on my server.