### PR TITLE
fix: LIMIT_MAKER does not require timeInForce

### DIFF
--- a/node-binance-api.js
+++ b/node-binance-api.js
@@ -250,7 +250,9 @@ let api = function Binance() {
         if (typeof flags.type !== 'undefined') opt.type = flags.type;
         if (opt.type.includes('LIMIT')) {
             opt.price = price;
-            opt.timeInForce = 'GTC';
+            if (opt.type !== 'LIMIT_MAKER') {
+                opt.timeInForce = 'GTC';
+            }
         }
         if (typeof flags.timeInForce !== 'undefined') opt.timeInForce = flags.timeInForce;
         if (typeof flags.newOrderRespType !== 'undefined') opt.newOrderRespType = flags.newOrderRespType;


### PR DESCRIPTION
Error: `{"code":-1106,"msg":"Parameter 'timeInForce' sent when not required."}`
API Docs: https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#new-order--trade