### PR TITLE
Allow withdrawals without an address name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1575,6 +1575,13 @@ binance.withdraw("ETH", "0x1d2034348c851ea29c7d03731c7968a5bcc91564", 1, false, 
 binance.withdraw("BTC", "1C5gqLRs96Xq4V2ZZAR1347yUCpHie7sa", 0.2);
 ```
 
+#### Withdraw with custom name
+```js
+// let name = false // Falsy value won't save address to address book
+let name = 'My Withdrawal Address'
+binance.withdraw("BTC", "1C5gqLRs96Xq4V2ZZAR1347yUCpHie7sa", 0.2, undefined, name)
+```
+
 #### [Advanced Examples](https://github.com/jaggedsoft/node-binance-api/blob/master/examples/advanced.md)
 > [exchangeInfo: Pull minimum order size, quantity, etc](https://github.com/jaggedsoft/node-binance-api/blob/master/examples/advanced.md#exchangeinfo-pull-minimum-order-size-quantity-etc)\
 [Clamp order quantities to required amounts via minQty, minNotional, stepSize when placing orders](https://github.com/jaggedsoft/node-binance-api/blob/master/examples/advanced.md#clamp-order-quantities-to-required-amounts-via-minqty-minnotional-stepsize-when-placing-orders)\
@@ -1660,4 +1667,3 @@ Thank you to all contributors: bmino, dmzoneill, dmitriz, keith1024, pavlovdog, 
 [![Views](http://hits.dwyl.io/jaggedsoft/node-binance-api.svg)](http://hits.dwyl.io/jaggedsoft/node-binance-api)
 [![jaggedsoft on Twitter](https://img.shields.io/twitter/follow/jaggedsoft.svg?style=social)](https://twitter.com/jaggedsoft)
 [![Chartaholic on Twitter](https://img.shields.io/twitter/follow/Chartaholic.svg?style=social)](https://twitter.com/Chartaholic)
-

--- a/node-binance-api.js
+++ b/node-binance-api.js
@@ -1626,6 +1626,7 @@ let api = function Binance() {
         * @param {object} data - the data to send
         * @param {function} callback - the callback function
         * @param {string} method - the http method
+        * @param {boolean} noDataInSignature - Prevents data from being added to signature
         * @return {undefined}
         */
         signedRequest: function (url, data, callback, method = 'GET', noDataInSignature) {

--- a/node-binance-api.js
+++ b/node-binance-api.js
@@ -584,7 +584,7 @@ let api = function Binance() {
             return convertData(data);
         }
     }
-    
+
     /**
      * Parses the previous day stream and calls the user callback with friendly object
      * @param {object} data - user data callback data type
@@ -1627,8 +1627,8 @@ let api = function Binance() {
         * @param {string} method - the http method
         * @return {undefined}
         */
-        signedRequest: function (url, data, callback, method = 'GET') {
-            signedRequest(url, data, callback, method);
+        signedRequest: function (url, data, callback, method = 'GET', noDataInSignature) {
+            signedRequest(url, data, callback, method, noDataInSignature);
         },
 
         /**

--- a/node-binance-api.js
+++ b/node-binance-api.js
@@ -197,14 +197,15 @@ let api = function Binance() {
      * @param {object} data - The data to send
      * @param {function} callback - The callback method to call
      * @param {string} method - the http method
+     * @param {boolean} noDataInSignature - Prevents data from being added to signature
      * @return {undefined}
      */
-    const signedRequest = function (url, data = {}, callback, method = 'GET') {
+    const signedRequest = function (url, data = {}, callback, method = 'GET', noDataInSignature = false) {
         if (!Binance.options.APIKEY) throw Error('apiRequest: Invalid API Key');
         if (!Binance.options.APISECRET) throw Error('signedRequest: Invalid API Secret');
         data.timestamp = new Date().getTime() + Binance.info.timeOffset;
         if (typeof data.recvWindow === 'undefined') data.recvWindow = Binance.options.recvWindow;
-        let query = method === 'POST' && data.name === 'API Withdraw' ? '' : Object.keys(data).reduce(function (a, k) {
+        let query = method === 'POST' && noDataInSignature ? '' : Object.keys(data).reduce(function (a, k) {
             a.push(k + '=' + encodeURIComponent(data[k]));
             return a;
         }, []).join('&');

--- a/node-binance-api.js
+++ b/node-binance-api.js
@@ -1386,13 +1386,14 @@ let api = function Binance() {
         * @param {number} amount - the amount to transfer
         * @param {string} addressTag - and addtional address tag
         * @param {function} callback - the callback function
+        * @param {string} name - the name to save the address as. Set falsy to prevent Binance saving to address book
         * @return {undefined}
         */
-        withdraw: function (asset, address, amount, addressTag = false, callback = false) {
+        withdraw: function (asset, address, amount, addressTag = false, callback = false, name = 'API Withdraw') {
             let params = { asset, address, amount };
-            params.name = 'API Withdraw';
             if (addressTag) params.addressTag = addressTag;
-            signedRequest(wapi + 'v3/withdraw.html', params, callback, 'POST');
+            if (name) params.name = name
+            signedRequest(wapi + 'v3/withdraw.html', params, callback, 'POST', true);
         },
 
         /**

--- a/test.js
+++ b/test.js
@@ -685,6 +685,22 @@ describe('Withdraw', function () {
       done();
     });
   }).timeout(TIMEOUT);
+
+  it('Attempt to withdraw BNB without saving to address book', function (done) {
+    binance.withdraw('BNBBTC', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', '5', false, (error, result) => {
+      debug(error);
+      debug(result);
+      assert(typeof (error) === 'object', WARN_SHOULD_BE_OBJ);
+      assert(typeof (result) === 'object', WARN_SHOULD_BE_OBJ);
+      assert(error === null, WARN_SHOULD_BE_NULL);
+      assert(result !== null, WARN_SHOULD_BE_NOT_NULL);
+      assert(Object.prototype.hasOwnProperty.call(result, 'msg'), WARN_SHOULD_HAVE_KEY + 'msg');
+      assert(result.msg === 'You don\'t have permission.');
+      assert(Object.prototype.hasOwnProperty.call(result, 'success'), WARN_SHOULD_HAVE_KEY + 'success');
+      assert(result.success === false);
+      done();
+    }, false);
+  }).timeout(TIMEOUT);
 });
 
 describe('Withdraw history', function () {


### PR DESCRIPTION
### The issue
When Binance receives a `name` property on a withdrawal request, they save it to the address book.

This address book has a limit, and if many withdrawals are processed, and the limit is reached, then Binance will start rejecting the withdrawals

### Reason for PR
The previous code used a hard coded value of `'API Withdraw'` which meant all withdrawal requests saved the address to the address book. This hard coded value was also used in the logic of the `signedRequest` function, to determine if the `signature` should be update with the contents of the `data` parameter

### What this PR does
This pull request allows for developers to both set a custom address name, as well as opting not to supply any name (meaning that the address won't be saved to the address book at all). It also maintains the previous functionality by defaulting the name to `'API Withdraw'` for complete backwards compatibility.

Due to the reliance on the hard coded `data.name` value, I have updated the `signedRequest` function to take a `noDataInSignature` argument which is now what decides if the `signature` shouldn't be updated with the `data` parameter value

I have added documentation both via the in code JSDocs format, as well as in the `README.md` file. I have also added a test for mocha