### PR TITLE
Don't include undefined values in query string and signature

### DIFF
--- a/node-binance-api.js
+++ b/node-binance-api.js
@@ -131,7 +131,12 @@ let api = function Binance() {
         proxyRequest( opt, callback );
     };
 
-    const makeQueryString = q => Object.keys( q ).reduce( ( a,k )=>{a.push( k+'='+encodeURIComponent( q[k] ) );return a},[] ).join( '&' );
+    const makeQueryString = q => Object.keys( q ).reduce( ( a,k )=>{
+      if (q[k] !== undefined) {
+        a.push( k+'='+encodeURIComponent( q[k] ) )
+      }
+      return a
+    }, []).join( '&' );
 
     /**
      * Create a http request to the public API


### PR DESCRIPTION
It seems that Binance now reject undefined values in query string signatures. The current 
`makeQueryString` function uses `Object.keys` which will iterate over set but undefined keys, and will create a signature including it, which is subsequently rejected by Binance:

```json
{
  "msg": "Signature for this request is not valid.",
  "success": false
}
```

This change excludes undefined key value pairs from the query string. You can reproduce this issue via the following code where `args.endTime` is undefined

```javascript
const Binance = require('node-binance-api')

const args = {
  startTime: Date.now() - 60 * 1000
}

Binance.signedRequest('https://api.binance.com/wapi/v3/withdrawHistory.html', { startTime: args.startTime, endTime: args.endTime }, (error, response) => {
  if (error) {
    throw error
  }
  console.log(response)
})
```

