### PR TITLE
Allow custom timeInForce param in futures orders

### DIFF
--- a/node-binance-api.js
+++ b/node-binance-api.js
@@ -370,7 +370,9 @@ let api = function Binance( options = {} ) {
         } else {
             if ( typeof params.type === 'undefined' ) params.type = 'MARKET';
         }
-        if ( params.type.includes( 'LIMIT' ) || params.type === 'STOP' || params.type === 'TAKE_PROFIT' ) params.timeInForce = 'GTC';
+        if ( !params.timeInForce 
+            && ( params.type.includes( 'LIMIT' ) || params.type === 'STOP' || params.type === 'TAKE_PROFIT' ) ) 
+            params.timeInForce = 'GTC';
         return promiseRequest( 'v1/order', params, {base:fapi, type:'TRADE', method:'POST'} );
     };
     const promiseRequest = async ( url, data = {}, flags = {} ) => {


### PR DESCRIPTION
Fixes issue #396 
'GTX' should also be considered as the default value instead of 'GTC': 
It's the default on Binance and it avoids unexpected/unwanted taker side orders.