### PR TITLE
Increase Depth Update Speed

### DIFF
--- a/node-binance-api.js
+++ b/node-binance-api.js
@@ -3709,7 +3709,7 @@ let api = function Binance( options = {} ) {
                     if ( !isArrayUnique( symbols ) ) throw Error( 'depthCache: "symbols" cannot contain duplicate elements.' );
                     symbols.forEach( symbolDepthInit );
                     let streams = symbols.map( function ( symbol ) {
-                        return symbol.toLowerCase() + '@depth';
+                        return symbol.toLowerCase() + `@depth@100ms`;
                     } );
                     subscription = subscribeCombined( streams, handleDepthStreamData, reconnect, function () {
                         async.mapLimit( symbols, 50, getSymbolDepthSnapshot, ( err, results ) => {
@@ -3721,7 +3721,7 @@ let api = function Binance( options = {} ) {
                 } else {
                     let symbol = symbols;
                     symbolDepthInit( symbol );
-                    subscription = subscribe( symbol.toLowerCase() + '@depth', handleDepthStreamData, reconnect, function () {
+                    subscription = subscribe( symbol.toLowerCase() + `@depth@100ms`, handleDepthStreamData, reconnect, function () {
                         async.mapLimit( [symbol], 1, getSymbolDepthSnapshot, ( err, results ) => {
                             if ( err ) throw err;
                             results.forEach( updateSymbolDepthCache );

--- a/node-binance-api.js
+++ b/node-binance-api.js
@@ -3614,12 +3614,12 @@ let api = function Binance( options = {} ) {
                 if ( Array.isArray( symbols ) ) {
                     if ( !isArrayUnique( symbols ) ) throw Error( 'depth: "symbols" cannot contain duplicate elements.' );
                     let streams = symbols.map( function ( symbol ) {
-                        return symbol.toLowerCase() + '@depth';
+                        return symbol.toLowerCase() + '@depth@100ms';
                     } );
                     subscription = subscribeCombined( streams, callback, reconnect );
                 } else {
                     let symbol = symbols;
-                    subscription = subscribe( symbol.toLowerCase() + '@depth', callback, reconnect );
+                    subscription = subscribe( symbol.toLowerCase() + '@depth@100ms', callback, reconnect );
                 }
                 return subscription.endpoint;
             },


### PR DESCRIPTION
Binance has since updated their api to allow for depth related websockets to push information every 100ms instead of the previous 1000ms. This PR upgrades the following websocket endpoints to update at the faster interval:

* depth
* depthCache
* depthCacheStaggered (as a proxy)

This addresses issue #425 and provides an alternative solution to PR #426