### PR TITLE
Implement futureUserDataStream and add indexPrice to futureMarkPriceStream

### DIFF
--- a/node-binance-api.js
+++ b/node-binance-api.js
@@ -987,7 +987,7 @@ let api = function Binance( options = {} ) {
         } = data.o;
         return { symbol, side, orderType, timeInForce, origAmount, price, avgPrice, orderStatus, lastFilledQty, totalFilledQty, eventType, tradeTime, eventTime };
     };
-    
+
     /**
      * Converts the futures ticker stream data into a friendly object
      * @param {object} data - user data callback data type
@@ -1108,7 +1108,225 @@ let api = function Binance( options = {} ) {
             bestAsk,
             bestAskQty
         };
-    }
+    };
+
+    /**
+     * Converts the futures UserData stream MARGIN_CALL data into a friendly object
+     * @param {object} data - user data callback data type
+     * @return {object} - user friendly data type
+     */
+    const fUserDataMarginConvertData = data => {
+        let {
+            e: eventType,
+            E: eventTime,
+            cw: crossWalletBalance, // only pushed with crossed position margin call
+            p: positions
+        } = data;
+        let positionConverter = position => {
+            let {
+                s: symbol,
+                ps: positionSide,
+                pa: positionAmount,
+                mt: marginType,
+                iw: isolatedWallet, // if isolated position
+                mp: markPrice,
+                up: unrealizedPnL,
+                mm: maintenanceMargin // maintenance margin required
+            } = position;
+            return {
+                symbol,
+                positionSide,
+                positionAmount,
+                marginType,
+                isolatedWallet,
+                markPrice,
+                unrealizedPnL,
+                maintenanceMargin
+            }
+        };
+        const convertedPositions = [];
+        for ( let position of positions ) {
+            convertedPositions.push( positionConverter( position ) );
+        }
+        positions = convertedPositions;
+        return {
+            eventType,
+            eventTime,
+            crossWalletBalance,
+            positions
+        };
+    };
+
+    /**
+     * Converts the futures UserData stream ACCOUNT_UPDATE data into a friendly object
+     * @param {object} data - user data callback data type
+     * @return {object} - user friendly data type
+     */
+    const fUserDataAccountUpdateConvertData = data => {
+        let {
+            e: eventType,
+            E: eventTime,
+            T: transaction,
+            a: updateData
+        } = data;
+        let updateConverter = updateData => {
+            let {
+                m: eventReasonType,
+                B: balances,
+                P: positions
+            } = updateData;
+            let positionConverter = position => {
+                let {
+                    s: symbol,
+                    pa: positionAmount,
+                    ep: entryPrice,
+                    cr: accumulatedRealized, // (Pre-fee) Accumulated Realized
+                    up: unrealizedPnL,
+                    mt: marginType,
+                    iw: isolatedWallet, // if isolated position
+                    ps: positionSide
+                } = position;
+                return {
+                    symbol,
+                    positionAmount,
+                    entryPrice,
+                    accumulatedRealized,
+                    unrealizedPnL,
+                    marginType,
+                    isolatedWallet,
+                    positionSide
+                };
+            };
+            let balanceConverter = balance => {
+                let {
+                    a: asset,
+                    wb: walletBalance,
+                    cw: crossWalletBalance
+                } = balance;
+                return {
+                    asset,
+                    walletBalance,
+                    crossWalletBalance
+                }
+            };
+
+            const balanceResult= [];
+            const positionResult= [];
+
+            for ( let balance of balances ) {
+                balanceResult.push( balanceConverter( balance ) );
+            }
+            for ( let position of positions ) {
+                positionResult.push( positionConverter( position ) );
+            }
+
+            balances = balanceResult;
+            positions = positionResult;
+            return {
+                eventReasonType,
+                balances,
+                positions
+            };
+        };
+        updateData = updateConverter(updateData);
+        return {
+            eventType,
+            eventTime,
+            transaction,
+            updateData
+        };
+    };
+
+    /**
+     * Converts the futures UserData stream ORDER_TRADE_UPDATE data into a friendly object
+     * @param {object} data - user data callback data type
+     * @return {object} - user friendly data type
+     */
+    const fUserDataOrderUpdateConvertData = data => {
+        let {
+            e: eventType,
+            E: eventTime,
+            T: transaction, // transaction time
+            o: order
+        } = data;
+
+        let orderConverter = order => {
+            let {
+                s: symbol,
+                c: clientOrderId,
+                // special client order id:
+                // starts with "autoclose-": liquidation order
+                // "adl_autoclose": ADL auto close order
+                S: side,
+                o: orderType,
+                f: timeInForce,
+                q: originalQuantity,
+                p: originalPrice,
+                ap: averagePrice,
+                sp: stopPrice, // please ignore with TRAILING_STOP_MARKET order,
+                x: executionType,
+                X: orderStatus,
+                i: orderId,
+                l: orderLastFilledQuantity,
+                z: orderFilledAccumulatedQuantity,
+                L: lastFilledPrice,
+                N: commissionAsset, // will not push if no commission
+                n: commission, // will not push if no commission
+                T: orderTradeTime,
+                t: tradeId,
+                b: bidsNotional,
+                a: askNotional,
+                m: isMakerSide, // is this trade maker side
+                R: isReduceOnly, // is this reduce only
+                wt: stopPriceWorkingType,
+                ot: originalOrderType,
+                ps: positionSide,
+                cp: closeAll, // if close-all, pushed with conditional order
+                AP: activationPrice, // only pushed with TRAILING_STOP_MARKET order
+                cr: callbackRate, // only pushed with TRAILING_STOP_MARKET order
+                rp: realizedProfit
+            } = order;
+            return {
+                symbol,
+                clientOrderId,
+                side,
+                orderType,
+                timeInForce,
+                originalQuantity,
+                originalPrice,
+                averagePrice,
+                stopPrice,
+                executionType,
+                orderStatus,
+                orderId,
+                orderLastFilledQuantity,
+                orderFilledAccumulatedQuantity,
+                lastFilledPrice,
+                commissionAsset,
+                commission,
+                orderTradeTime,
+                tradeId,
+                bidsNotional,
+                askNotional,
+                isMakerSide,
+                isReduceOnly,
+                stopPriceWorkingType,
+                originalOrderType,
+                positionSide,
+                closeAll,
+                activationPrice,
+                callbackRate,
+                realizedProfit
+            };
+        };
+        order = orderConverter(order);
+        return {
+            eventType,
+            eventTime,
+            transaction,
+            order
+        };
+    };
 
     /**
      * Converts the futures markPrice stream data into a friendly object
@@ -1122,6 +1340,7 @@ let api = function Binance( options = {} ) {
                 E: eventTime,
                 s: symbol,
                 p: markPrice,
+                i: indexPrice,
                 r: fundingRate,
                 T: fundingTime
             } = data;
@@ -1130,6 +1349,7 @@ let api = function Binance( options = {} ) {
                 eventTime,
                 symbol,
                 markPrice,
+                indexPrice,
                 fundingRate,
                 fundingTime
             };
@@ -1687,6 +1907,28 @@ let api = function Binance( options = {} ) {
             if ( Binance.options.margin_list_status_callback ) Binance.options.margin_list_status_callback( data );
         } else if ( type === 'outboundAccountPosition' ) {
             // TODO: Does this mean something?
+        } else {
+            Binance.options.log( 'Unexpected userMarginData: ' + type );
+        }
+    };
+
+    /**
+     * Used as part of the user data websockets callback
+     * @param {object} data - user data callback data type
+     * @return {undefined}
+     */
+    const userFutureDataHandler = data => {
+        let type = data.e;
+        if ( type === 'MARGIN_CALL' ) {
+            Binance.options.future_margin_call_callback( fUserDataMarginConvertData(data) );
+        } else if ( type === 'ACCOUNT_UPDATE' ) {
+            if ( Binance.options.future_account_update_callback ) {
+                Binance.options.future_account_update_callback( fUserDataAccountUpdateConvertData(data));
+            }
+        } else if ( type === 'ORDER_TRADE_UPDATE' ) {
+            if ( Binance.options.future_order_update_callback ) {
+                Binance.options.future_order_update_callback( fUserDataOrderUpdateConvertData(data));
+            }
         } else {
             Binance.options.log( 'Unexpected userMarginData: ' + type );
         }
@@ -3446,20 +3688,20 @@ let api = function Binance( options = {} ) {
             params.symbol = symbol;
             return promiseRequest( 'v1/aggTrades', params, { base:fapi } );
         },
-        
+
         futuresForceOrders: async ( params = {} ) => {
             return promiseRequest( 'v1/forceOrders', params, { base:fapi, type:'SIGNED' } );
         },
-        
+
         futuresDeleverageQuantile: async ( params = {} ) => {
             return promiseRequest( 'v1/adlQuantile', params, { base:fapi, type:'SIGNED' } );
         },
-        
+
         futuresUserTrades: async ( symbol, params = {} ) => {
             params.symbol = symbol;
             return promiseRequest( 'v1/userTrades', params, { base:fapi, type:'SIGNED' } );
         },
-        
+
         futuresGetDataStream: async ( params = {} ) => {
             //A User Data Stream listenKey is valid for 60 minutes after creation. setInterval
             return promiseRequest( 'v1/listenKey', params, { base:fapi, type:'SIGNED', method:'POST' } );
@@ -3477,7 +3719,7 @@ let api = function Binance( options = {} ) {
             if ( symbol ) params.symbol = symbol;
             return promiseRequest( 'v1/allForceOrders', params, { base:fapi } );
         },
-        
+
         futuresPositionRisk: async ( params = {} ) => {
             return promiseRequest( 'v2/positionRisk', params, { base:fapi, type:'SIGNED' } );
         },
@@ -3513,12 +3755,12 @@ let api = function Binance( options = {} ) {
             params.type = type;
             return promiseRequest( 'v1/positionMargin', params, { base:fapi, method:'POST', type:'SIGNED' } );
         },
-        
+
         futuresPositionMarginHistory: async ( symbol, params = {} ) => {
             params.symbol = symbol;
             return promiseRequest( 'v1/positionMargin/history', params, { base:fapi, type:'SIGNED' } );
         },
-        
+
         futuresIncome: async ( params = {} ) => {
             return promiseRequest( 'v1/income', params, { base:fapi, type:'SIGNED' } );
         },
@@ -3559,9 +3801,9 @@ let api = function Binance( options = {} ) {
         futuresMarketSell: async ( symbol, quantity, params = {} ) => {
             return futuresOrder( 'SELL', symbol, quantity, false, params );
         },
-        
+
         futuresOrder, // side symbol quantity [price] [params]
-        
+
         futuresOrderStatus: async ( symbol, params = {} ) => { // Either orderId or origClientOrderId must be sent
             params.symbol = symbol;
             return promiseRequest( 'v1/order', params, { base:fapi, type:'SIGNED' } );
@@ -3610,7 +3852,7 @@ let api = function Binance( options = {} ) {
         Cancel multiple orders DELETE /fapi/v1/batchOrders
         New Future Account Transfer POST https://api.binance.com/sapi/v1/futures/transfer
         Get Postion Margin Change History (TRADE)
-        
+
         wss://fstream.binance.com/ws/<listenKey>
         Diff. Book Depth Streams (250ms, 100ms, or realtime): <symbol>@depth OR <symbol>@depth@100ms OR <symbol>@depth@0ms
         Partial Book Depth Streams (5, 10, 20): <symbol>@depth<levels> OR <symbol>@depth<levels>@100ms
@@ -3969,7 +4211,7 @@ let api = function Binance( options = {} ) {
                     return callback.call( this, error, data, symbol );
                 } );
             }
-        },      
+        },
 
         /**
          * Gets the status of an order
@@ -4192,7 +4434,7 @@ let api = function Binance( options = {} ) {
             let subscription = futuresSubscribeSingle( endpoint + speed, data => callback( fMarkPriceConvertData( data ) ), { reconnect } );
             return subscription.endpoint;
         },
-        
+
         /**
          * Futures WebSocket liquidations stream
          * @param {symbol} symbol name or false. can also be a callback
@@ -4439,7 +4681,7 @@ let api = function Binance( options = {} ) {
             let subscription = deliverySubscribeSingle( endpoint + speed, data => callback( dMarkPriceConvertData( data ) ), { reconnect } );
             return subscription.endpoint;
         },
-        
+
         /**
          * Delivery WebSocket liquidations stream
          * @param {symbol} symbol name or false. can also be a callback
@@ -4665,6 +4907,35 @@ let api = function Binance( options = {} ) {
                     Binance.options.margin_execution_callback = execution_callback;
                     Binance.options.margin_list_status_callback = list_status_callback;
                     const subscription = subscribe( Binance.options.listenMarginKey, userMarginDataHandler, reconnect );
+                    if ( subscribed_callback ) subscribed_callback( subscription.endpoint );
+                }, 'POST' );
+            },
+
+            /**
+             * Future Userdata websockets function
+             * @param {function} margin_call_callback
+             * @param {function} account_update_callback
+             * @param {function} order_update_callback
+             * @param {Function} subscribed_callback - subscription callback
+             */
+            userFutureData: function userFutureData( margin_call_callback, account_update_callback = undefined, order_update_callback = undefined, subscribed_callback = undefined) {
+                const url = ( Binance.options.test ) ? fapiTest : fapi;
+                apiRequest( url + 'v1/listenKey', {}, function ( error, response ) {
+                    Binance.options.listenFutureKey = response.listenKey;
+                    setTimeout( function userDataKeepAlive() { // keepalive
+                        try {
+                            apiRequest( fapi + 'v1/userDataStream?listenKey=' + Binance.options.listenFutureKey, {}, function ( err ) {
+                                if ( err ) setTimeout( userDataKeepAlive, 60000 ); // retry in 1 minute
+                                else setTimeout( userDataKeepAlive, 60 * 30 * 1000 ); // 30 minute keepalive
+                            }, 'PUT' );
+                        } catch ( error ) {
+                            setTimeout( userDataKeepAlive, 60000 ); // retry in 1 minute
+                        }
+                    }, 60 * 30 * 1000 ); // 30 minute keepalive
+                    Binance.options.future_margin_call_callback = margin_call_callback;
+                    Binance.options.future_account_update_callback = account_update_callback;
+                    Binance.options.future_order_update_callback = order_update_callback;
+                    const subscription = futuresSubscribe( Binance.options.listenFutureKey, userFutureDataHandler, Binance.options.reconnect );
                     if ( subscribed_callback ) subscribed_callback( subscription.endpoint );
                 }, 'POST' );
             },


### PR DESCRIPTION
I have implemented futureUserData stream, and have added missing indexPrice from futureMarkPriceStream

https://binance-docs.github.io/apidocs/futures/en/#event-order-update
```
/**
             * Future Userdata websockets function
             * @param {function} margin_call_callback
             * @param {function} account_update_callback
             * @param {function} order_update_callback
             * @param {Function} subscribed_callback - subscription callback
             */
            userFutureData: function userFutureData( margin_call_callback, account_update_callback = undefined, order_update_callback = undefined, subscribed_callback = undefined) {..}
```

sample usage:
```
const BinanceClient = require('node-binance-api');
const binance = new BinanceClient().options({
      APIKEY: some_string,
      APISECRET: some_other_string
});
binance.websockets.userFutureData(console.log, console.log, console.log);
```

sample output:
```
{
  eventType: 'ORDER_TRADE_UPDATE',
  eventTime: 1598875470985,
  transaction: 1598875470984,
  order: {
    symbol: 'BTCUSDT',
    clientOrderId: asd',
    side: 'BUY',
    orderType: 'LIMIT',
    timeInForce: 'GTC',
    originalQuantity: '0.001',
    originalPrice: '11612.21',
    averagePrice: '0',
    stopPrice: '0',
    executionType: 'NEW',
    orderStatus: 'NEW',
    orderId: 123,
    orderLastFilledQuantity: '0',
    orderFilledAccumulatedQuantity: '0',
    lastFilledPrice: '0',
    commissionAsset: undefined,
    commission: undefined,
    orderTradeTime: 1598875470984,
    tradeId: 0,
    bidsNotional: '11.61221',
    askNotional: '0',
    isMakerSide: false,
    isReduceOnly: false,
    stopPriceWorkingType: 'CONTRACT_PRICE',
    originalOrderType: 'LIMIT',
    positionSide: 'BOTH',
    closeAll: false,
    activationPrice: undefined,
    callbackRate: undefined,
    realizedProfit: '0'
  }
}
```