### PR TITLE
fix: deprecate outboundAccountInfo

### DIFF
--- a/node-binance-api.js
+++ b/node-binance-api.js
@@ -1880,13 +1880,13 @@ let api = function Binance( options = {} ) {
     const userDataHandler = data => {
         let type = data.e;
         if ( type === 'outboundAccountInfo' ) {
-            Binance.options.balance_callback( data );
+          // XXX: Deprecated in 2020-09-08
         } else if ( type === 'executionReport' ) {
             if ( Binance.options.execution_callback ) Binance.options.execution_callback( data );
         } else if ( type === 'listStatus' ) {
             if ( Binance.options.list_status_callback ) Binance.options.list_status_callback( data );
         } else if ( type === 'outboundAccountPosition' ) {
-            // TODO: Does this mean something?
+            Binance.options.balance_callback( data );
         } else {
             Binance.options.log( 'Unexpected userData: ' + type );
         }


### PR DESCRIPTION
Fixes #491

Ideally this would warrant a breaking change of the library
but since the new endpoint returns a subset that is consistent
with previous behavior, and understanding the risk assessment
of letting thousands of consumers of the library have their applications
be broken, it seems smart to pipe one stream into the other.