### PR TITLE
FIX: added speed param in futuresMarkPriceStream reconnect

### DIFF
--- a/node-binance-api.js
+++ b/node-binance-api.js
@@ -4463,7 +4463,7 @@ let api = function Binance( options = {} ) {
                 symbol = false;
             }
             let reconnect = () => {
-                if ( Binance.options.reconnect ) fMarkPriceStream( symbol, callback );
+                if ( Binance.options.reconnect ) fMarkPriceStream( symbol, callback, speed);
             };
             const endpoint = symbol ? `${ symbol.toLowerCase() }@markPrice` : '!markPrice@arr'
             let subscription = futuresSubscribeSingle( endpoint + speed, data => callback( fMarkPriceConvertData( data ) ), { reconnect } );


### PR DESCRIPTION
Hi,

I am using the futures prices websocket stream but only require 3s intervals, hence when intially starting the websocket, I pass an empty string as the third parameter. During production, I noticed that after reconnecting (due to some disconnect), I receive data with a 1s interval. A quick check showed, that the speed param is not passed into the reconnect function.

I added the speed param to the reconnect signature in the futuresMarkPriceStream function.