### PR TITLE
Set orderStatus to not force orderid, It can use the flags to find th…

### DIFF
--- a/node-binance-api.js
+++ b/node-binance-api.js
@@ -2973,13 +2973,17 @@ let api = function Binance( options = {} ) {
         /**
         * Gets the status of an order
         * @param {string} symbol - the symbol to check
-        * @param {string} orderid - the orderid to check
+        * @param {string} orderid - the orderid to check if !orderid then  use flags to search
         * @param {function} callback - the callback function
         * @param {object} flags - any additional flags
         * @return {promise or undefined} - omitting the callback returns a promise
         */
         orderStatus: function ( symbol, orderid, callback, flags = {} ) {
-            let parameters = Object.assign( { symbol: symbol, orderId: orderid }, flags );
+            let parameters = Object.assign( { symbol: symbol }, flags );
+            if (orderid){
+                Object.assign( { orderId: orderid }, parameters )
+            }
+
             if ( !callback ) {
                 return new Promise( ( resolve, reject ) => {
                     callback = ( error, response ) => {


### PR DESCRIPTION
Set orderStatus to not force orderid, It can use the flags to find the orderid / origClientOrderId as per the binance api information

as per https://github.com/jaggedsoft/node-binance-api/issues/669 

and

https://github.com/binance/binance-spot-api-docs/blob/master/rest-api.md#query-order-user_data