### PR TITLE
break: use sapi endpoints instead of wapi

### DIFF
--- a/node-binance-api.js
+++ b/node-binance-api.js
@@ -3091,10 +3091,10 @@ let api = function Binance( options = {} ) {
                             resolve( response );
                         }
                     }
-                    signedRequest( wapi + '/v3/userAssetDribbletLog.html', {}, callback );
+                  signedRequest( sapi + 'v1/asset/dribblet', {}, callback );
                 } )
             } else {
-                signedRequest( wapi + '/v3/userAssetDribbletLog.html', {}, callback );
+                signedRequest( sapi + 'v1/asset/dribblet', {}, callback );
             }
         },
 
@@ -3175,10 +3175,10 @@ let api = function Binance( options = {} ) {
                             resolve( response );
                         }
                     }
-                    signedRequest( wapi + 'v3/withdrawHistory.html', params, callback );
+                    signedRequest( sapi + 'v1/capital/withdraw/history', params, callback );
                 } )
             } else {
-                signedRequest( wapi + 'v3/withdrawHistory.html', params, callback );
+                signedRequest( sapi + 'v1/capital/withdraw/history', params, callback );
             }
         },
 
@@ -3199,10 +3199,10 @@ let api = function Binance( options = {} ) {
                             resolve( response );
                         }
                     }
-                    signedRequest( wapi + 'v3/depositHistory.html', params, callback );
+                    signedRequest( sapi + 'v1/capital/deposit/hisrec', params, callback );
                 } )
             } else {
-                signedRequest( wapi + 'v3/depositHistory.html', params, callback );
+                signedRequest( sapi + 'v1/capital/deposit/hisrec', params, callback );
             }
         },
 


### PR DESCRIPTION
Updates these functions w.r.t. #667:

- depositHistory
- withdrawHistory
- dustLog

This is a *breaking change* as the sapi endpoints return different data structures than the wapi ones.