### PR TITLE
This change is required to listen for Orders

### DIFF
--- a/node-binance-api.js
+++ b/node-binance-api.js
@@ -5220,7 +5220,7 @@ let api = function Binance( options = {} ) {
                         }
                     }, 60 * 30 * 1000 ); // 30 minute keepalive
                     Binance.options.balance_callback = callback;
-                    Binance.options.execution_callback = execution_callback;
+                    Binance.options.execution_callback = execution_callback ? callback : execution_callback;//This change is required to listen for Orders
                     Binance.options.list_status_callback = list_status_callback;
                     const subscription = subscribe( Binance.options.listenKey, userDataHandler, reconnect );
                     if ( subscribed_callback ) subscribed_callback( subscription.endpoint );


### PR DESCRIPTION
If I do not make this change, it gives the error "Binance.options.execution_callback is not a function" in the following line of code;

"else if ( type === 'executionReport' ) {
            if ( Binance.options.execution_callback ) Binance.options.execution_callback( data );"

