### PR TITLE
[chore] options to return Binance type [ts]

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -451,6 +451,15 @@
         "maintenance", "code"
       ]
     },
+    {
+      "login": "shaunlwm",
+      "name": "Shaun Lim",
+      "avatar_url": "https://avatars.githubusercontent.com/u/37434846?v=4",
+      "profile": "https://github.com/ShaunLWM",
+      "contributions": [
+        "maintenance", "code"
+      ]
+    }
   ],
   "contributorsPerLine": 7
 }

--- a/node-binance-api.d.ts
+++ b/node-binance-api.d.ts
@@ -382,7 +382,7 @@ declare module "node-binance-api" {
         * @param {object} value - the value of the key
         * @return {undefined}
         */
-        setOption(key: string, value: any): Binance;
+        setOption<T extends keyof IConstructorArgs>(key: T, value: IConstructorArgs[T]): Binance;
         setOption(...args: any): Binance;
 
         /**

--- a/node-binance-api.d.ts
+++ b/node-binance-api.d.ts
@@ -382,8 +382,8 @@ declare module "node-binance-api" {
         * @param {object} value - the value of the key
         * @return {undefined}
         */
-        setOption(key: string, value: any): any;
-        setOption(...args: any): any;
+        setOption(key: string, value: any): Binance;
+        setOption(...args: any): Binance;
 
         /**
         * Gets an option given a key
@@ -443,7 +443,7 @@ declare module "node-binance-api" {
         getOptions(...args: any): any;
 
 
-        options(...args: any): any;
+        options(...args: any): Binance;
 
         /**
         * Creates an order
@@ -451,7 +451,7 @@ declare module "node-binance-api" {
         * @param {string} symbol - the symbol to buy
         * @param {numeric} quantity - the quantity required
         * @param {numeric} price - the price to pay for each unit
-        * @param {object} flags - aadditionalbuy order flags
+        * @param {object} flags - additional buy order flags
         * @param {function} callback - the callback function
         * @return {promise or undefined} - omitting the callback returns a promise
         */

--- a/node-binance-api.d.ts
+++ b/node-binance-api.d.ts
@@ -231,6 +231,8 @@ declare module "node-binance-api" {
             dstreamSingleTest: string;
         }>;
         timeOffset: number;
+        APIKEY: string;
+        APISECRET: string;
     }
 
     class Binance {

--- a/node-binance-api.d.ts
+++ b/node-binance-api.d.ts
@@ -445,6 +445,7 @@ declare module "node-binance-api" {
         getOptions(...args: any): any;
 
 
+        options(args: Partial<IConstructorArgs>): Binance;
         options(...args: any): Binance;
 
         /**


### PR DESCRIPTION
Returning the `Binance` type instead of `any` will allow users to have better typings.

Before
`binance.account()` is any `any` type + no autocompletion

After
`binance.account()` autocomplete + type hints for `.account` method

I may have some time to add more typings (probably more of Binance API result) to this. Looking for approval from @jaggedsoft 

Tagging @tripolskypetr because you're the original owner of the typings (if you have not done anything else yet)

Will update this PR if there are any more changes.

Edit 1: for https://github.com/jaggedsoft/node-binance-api/pull/724/commits/42dcdce6e46fafbcb0c2852da73c6d5c3bbd833e, I did not remove the second `setOption` in case I did something wrong. Advice is needed.

Edit 2: Similar to https://github.com/jaggedsoft/node-binance-api/pull/724/commits/c8d12d021e8bbe64c8b3b4fd28795be1063d9c4d as well