### PR TITLE
Fix for orderId in orderStatus

### DIFF
--- a/node-binance-api.js
+++ b/node-binance-api.js
@@ -3025,7 +3025,7 @@ let api = function Binance( options = {} ) {
         orderStatus: function ( symbol, orderid, callback, flags = {} ) {
             let parameters = Object.assign( { symbol: symbol }, flags );
             if (orderid){
-                Object.assign( { orderId: orderid }, parameters )
+                Object.assign( parameters, { orderId: orderid } )
             }
 
             if ( !callback ) {


### PR DESCRIPTION
Currently, we have many open issues about the orderId not being set in the parameters for the orderStatus function, this commit fix that issue, and people can use orderStatus again.

We can see all those issues here -> https://github.com/jaggedsoft/node-binance-api/issues?q=is%3Aissue+is%3Aopen+orderStatus