### PR TITLE
fix(futures-ws): reject mixed-category combined streams

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -33,6 +33,8 @@ jobs:
       run: npm run ts-test-static
     - name: Static Tests (JS CJS)
       run: npm run static-test
+    - name: Futures WS endpoint migration tests
+      run: npm run ws-tests-migration
     - name: Live Tests (TS ESM)
       run: npm run ts-test-live
     - name: CJS test

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "ws-tests": "mocha ./tests/binance-class-ws.test.ts",
     "ws-tests-spot": "mocha ./tests/binance-ws-spot.test.ts --exit",
     "ws-tests-futures": "mocha ./tests/binance-ws-futures.test.ts --exit",
+    "ws-tests-migration": "mocha ./tests/ws-endpoints-migration.test.ts --fgrep \"Live:\" --invert --exit",
     "ws-api-userdata-tests": "mocha ./tests/binance-ws-api-userdata.test.ts --exit",
     "ws-live-tests": "mocha ./tests/binance-ws-spot.test.ts ./tests/binance-ws-futures.test.ts ./tests/binance-ws-api-userdata.test.ts ./tests/binance-ws-api-ticker.test.ts --exit",
     "test-debug": "mocha --inspect-brk",

--- a/src/node-binance-api.ts
+++ b/src/node-binance-api.ts
@@ -1868,8 +1868,9 @@ export default class Binance {
         // of silently dropping data — subscribe to each category on its own connection.
         const category = this.classifyFuturesStream(streams[0]);
         const mismatch = streams.find(s => this.classifyFuturesStream(s) !== category);
-        if (mismatch) {
-            throw new Error(`futuresSubscribe: cannot combine '${category}' stream "${streams[0]}" with '${this.classifyFuturesStream(mismatch)}' stream "${mismatch}" on one connection. Binance routes futures streams to separate /public, /market and /private endpoints; subscribe to each category separately.`);
+        if (mismatch !== undefined) {
+            const mismatchCategory = this.classifyFuturesStream(mismatch);
+            throw new Error(`futuresSubscribe: cannot combine '${category}' stream "${streams[0]}" with '${mismatchCategory}' stream "${mismatch}" on one connection. Binance routes futures streams to separate /public, /market and /private endpoints; subscribe to each category separately.`);
         }
         const baseUrl = this.getFStreamUrl(category);
         let ws: any = undefined;

--- a/src/node-binance-api.ts
+++ b/src/node-binance-api.ts
@@ -1862,7 +1862,15 @@ export default class Binance {
         const httpsproxy = this.getHttpsProxy();
         let socksproxy = this.getSocksProxy();
         const queryParams = streams.join('/');
+        // Binance routes USDⓈ-M futures streams to separate endpoints by category
+        // (/public, /market, /private) and will not push cross-category streams on a
+        // single connection. Reject mixed-category combos so they fail loudly instead
+        // of silently dropping data — subscribe to each category on its own connection.
         const category = this.classifyFuturesStream(streams[0]);
+        const mismatch = streams.find(s => this.classifyFuturesStream(s) !== category);
+        if (mismatch) {
+            throw new Error(`futuresSubscribe: cannot combine '${category}' stream "${streams[0]}" with '${this.classifyFuturesStream(mismatch)}' stream "${mismatch}" on one connection. Binance routes futures streams to separate /public, /market and /private endpoints; subscribe to each category separately.`);
+        }
         const baseUrl = this.getFStreamUrl(category);
         let ws: any = undefined;
         if (socksproxy) {

--- a/tests/ws-endpoints-migration.test.ts
+++ b/tests/ws-endpoints-migration.test.ts
@@ -152,6 +152,34 @@ describe('Private stream URL uses query params for listenKey', function () {
     });
 });
 
+describe('futuresSubscribe rejects mixed-category combined streams', function () {
+    const listenKey = 'pqia91ma19a5s61cv6a81va65sdf19v8a65a1a5s61cv6a81va65sdf19v8a1a65a1a5s61cv6a81va65sd';
+
+    it('throws when mixing market and public streams', function () {
+        assert.throws(
+            () => binance.futuresSubscribe(['btcusdt@aggTrade', 'btcusdt@depth'], () => { }),
+            /cannot combine/
+        );
+    });
+
+    it('throws when mixing public and private streams', function () {
+        assert.throws(
+            () => binance.futuresSubscribe(['btcusdt@bookTicker', listenKey], () => { }),
+            /cannot combine/
+        );
+    });
+
+    it('names both offending categories in the error message', function () {
+        try {
+            binance.futuresSubscribe(['btcusdt@markPrice', 'btcusdt@bookTicker'], () => { });
+            assert.fail('expected futuresSubscribe to throw');
+        } catch (e) {
+            assert.match(e.message, /market/);
+            assert.match(e.message, /public/);
+        }
+    });
+});
+
 describe('Live: production market stream (aggTrade via /market/)', function () {
     let trade;
     let cnt = 0;


### PR DESCRIPTION
## Problem

The USDⓈ-M Futures WebSocket split ([Important WebSocket Change Notice](https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-market-streams/Important-WebSocket-Change-Notice), 2026-03-06) routes streams to three separate endpoints by data type:

- `/public` — `@bookTicker`, `!bookTicker`, `@depth*`
- `/market` — `@aggTrade`, `@markPrice`, kline, `@ticker`, `@miniTicker`, `@forceOrder`, `@compositeIndex`, `!contractInfo`, `@assetIndex`
- `/private` — user data (listenKey)

Binance **will not push cross-category streams on a single connection** — and legacy unrouted URLs were decommissioned 2026-04-23.

`futuresSubscribe()` derives the routing category from `streams[0]` only:

```js
const category = this.classifyFuturesStream(streams[0]);
const baseUrl = this.getFStreamUrl(category);
```

So a combined subscription that mixes categories — e.g. `futuresSubscribe(['btcusdt@aggTrade', 'btcusdt@depth'], cb)` — routes the whole connection to `/market` (from `@aggTrade`), and the `/public` `@depth` stream **silently receives no data**. No error, just missing data.

## Fix

Validate that every stream in a combined subscription resolves to the same category; throw a descriptive error otherwise. Callers then fail loudly and subscribe per category — which is also Binance's own recommendation (one connection per traffic type).

```
futuresSubscribe: cannot combine 'market' stream "btcusdt@aggTrade" with 'public' stream "btcusdt@depth" on one connection. Binance routes futures streams to separate /public, /market and /private endpoints; subscribe to each category separately.
```

All built-in helpers (`futuresAggTradeStream`, `futuresCandlesticksStream`, `futuresChart`, etc.) build homogeneous stream arrays, so **none are affected** — this only guards advanced/direct `futuresSubscribe([...])` calls that mix categories.

## Tests

Added hermetic tests (no sockets opened — the guard runs before `new WebSocket`) to `tests/ws-endpoints-migration.test.ts` covering market+public, public+private, and the error-message contents. Full non-live suite: 29 passing; `tsc --noEmit` clean.